### PR TITLE
feat(extension): 태그 기반 익스텐션 릴리즈 자동화 추가

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -1,0 +1,57 @@
+name: Release Extension
+
+on:
+  push:
+    tags:
+      - "extension@*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build & Release Extension
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/extension@}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Extension version: $TAG"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build extension
+        run: pnpm --filter extension build
+        env:
+          EXTENSION_VERSION: ${{ steps.version.outputs.tag }}
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
+          VITE_EXTENSION_KEY: ${{ secrets.VITE_EXTENSION_KEY }}
+
+      - name: Zip build output
+        run: |
+          cd apps/extension/dist/chrome
+          zip -r ../../../../retoday-extension-v${{ steps.version.outputs.tag }}.zip .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "Extension v${{ steps.version.outputs.tag }}"
+          tag_name: "extension@${{ steps.version.outputs.tag }}"
+          generate_release_notes: true
+          files: retoday-extension-v${{ steps.version.outputs.tag }}.zip

--- a/apps/extension/src/manifest.config.ts
+++ b/apps/extension/src/manifest.config.ts
@@ -1,11 +1,13 @@
 import type { ManifestV3Export } from "@crxjs/vite-plugin";
 
 export function createManifest(env: Record<string, string>): ManifestV3Export {
+  const version = env.EXTENSION_VERSION || "1.0.0";
+
   return {
     manifest_version: 3,
-    name: "ReToday",
-    version: "1.0.0",
-    description: "ReToday Extension",
+    name: "Retoday",
+    version,
+    description: "Retoday Extension",
     ...(env.VITE_EXTENSION_KEY && { key: env.VITE_EXTENSION_KEY }),
     permissions: ["tabs", "storage", "sidePanel", "identity"],
     action: {

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "lint": {
       "dependsOn": ["^lint"],


### PR DESCRIPTION

## 작업 내용
- extension 태그 푸시 시 GitHub Actions가 실행되도록 설정
- 익스텐션 빌드 후 zip 파일 생성
- GitHub Release 생성 및 산출물 업로드 자동화

## 기대 효과
- 수동으로 빌드/압축/업로드하던 릴리즈 과정을 자동화할 수 있음
- `extension@버전` 태그 기준으로 익스텐션 배포 이력을 관리할 수 있음
