### PR TITLE
feat(extension): GA4 analytics 도입 및 사용자 이벤트 수집 로직 추가

### DIFF
--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -14,6 +14,7 @@ import {
   getBrowserSessionById,
   visitBrowserSession,
 } from "@/services/browser.service";
+import analytics from "@/services/google-analytics.service";
 import type { StorageSession } from "@/types/storage";
 
 import { type ExtensionMessage, MESSAGE_TYPE } from "../types/messages";
@@ -23,6 +24,15 @@ const removedTabIds = new Set<number>();
 chrome.sidePanel
   .setPanelBehavior({ openPanelOnActionClick: true })
   .catch((error: unknown) => console.error(error));
+
+browser.runtime.onInstalled.addListener((details) => {
+  void analytics.fireEvent("extension_lifecycle", {
+    reason: details.reason,
+    ...(details.previousVersion != null
+      ? { previous_version: details.previousVersion }
+      : {}),
+  });
+});
 
 browser.windows.onRemoved.addListener(async () => {
   getBrowserSession().then((sessions) => {
@@ -78,7 +88,14 @@ browser.runtime.onMessage.addListener(
         return;
       }
 
-      return addBrowserSession(String(sender.tab?.id ?? ""), msg.data);
+      await addBrowserSession(String(sender.tab?.id ?? ""), msg.data);
+      try {
+        const host = new URL(msg.data.url).host;
+        void analytics.fireEvent("content_session_tracked", { host });
+      } catch {
+        /* invalid URL — skip GA */
+      }
+      return;
     }
 
     if (msg.type === MESSAGE_TYPE.GOOGLE_LOGIN) {
@@ -90,6 +107,7 @@ browser.runtime.onMessage.addListener(
           })
           .then((data: unknown) => {
             tokenStore.set(data as BackendLoginResponse);
+            void analytics.fireEvent("login", { method: "google" });
             chrome.runtime.sendMessage({ type: MESSAGE_TYPE.AUTH_CHANGED });
           });
       });

--- a/apps/extension/src/content/index.ts
+++ b/apps/extension/src/content/index.ts
@@ -1,8 +1,24 @@
 import { getPageSnapshot } from "@/content/get-page-metrics";
+import analytics from "@/services/google-analytics.service";
 import { type PageVisitedMessage } from "@/types/messages";
+
+/** GA page_location용 — 경로·쿼리 제외로 PII 노출 최소화 */
+function pageLocationOriginOnly(href: string): string {
+  try {
+    const u = new URL(href);
+    return `${u.protocol}//${u.host}/`;
+  } catch {
+    return "unknown";
+  }
+}
 
 function sendPageVisited() {
   const pageData = getPageSnapshot();
+
+  void analytics.firePageViewEvent(
+    document.title || "(no title)",
+    pageLocationOriginOnly(window.location.href),
+  );
 
   const message: PageVisitedMessage = {
     type: "PAGE_VISITED",

--- a/apps/extension/src/manifest.config.ts
+++ b/apps/extension/src/manifest.config.ts
@@ -19,7 +19,10 @@ export function createManifest(env: Record<string, string>): ManifestV3Export {
       client_id: env.VITE_GOOGLE_CLIENT_ID || "",
       scopes: ["profile", "email"],
     },
-    host_permissions: ["https://www.googleapis.com/*"],
+    host_permissions: [
+      "https://www.googleapis.com/*",
+      "https://www.google-analytics.com/*",
+    ],
     side_panel: {
       default_path: "src/side-panel/index.html",
     },

--- a/apps/extension/src/services/google-analytics.service.ts
+++ b/apps/extension/src/services/google-analytics.service.ts
@@ -15,6 +15,14 @@ const SESSION_EXPIRATION_IN_MIN = 30;
 
 type GaEventParams = Record<string, string | number | undefined>;
 
+type GaRequestBody = {
+  client_id: string;
+  events: Array<{
+    name: string;
+    params: GaEventParams;
+  }>;
+};
+
 class Analytics {
   debug: boolean;
 
@@ -24,6 +32,10 @@ class Analytics {
 
   get isConfigured(): boolean {
     return Boolean(MEASUREMENT_ID && API_SECRET);
+  }
+
+  get endpoint() {
+    return this.debug ? GA_DEBUG_ENDPOINT : GA_ENDPOINT;
   }
 
   getRandomId() {
@@ -42,13 +54,15 @@ class Analytics {
   // the extension is installed.
   async getOrCreateClientId() {
     let { clientId } = await chrome.storage.local.get("clientId");
+
     if (!clientId) {
-      // Generate a unique client ID, the actual value is not relevant. We use
-      // the <number>.<number> format since this is typical for GA client IDs.
+      // Generate a unique client ID, the actual value is not relevant.
+      // We use the <number>.<number> format since this is typical for GA client IDs.
       const unixTimestampSeconds = Math.floor(new Date().getTime() / 1000);
       clientId = `${this.getRandomId()}.${unixTimestampSeconds}`;
       await chrome.storage.local.set({ clientId });
     }
+
     return clientId;
   }
 
@@ -58,10 +72,12 @@ class Analytics {
     // Use storage.session because it is only in memory
     let { sessionData } = await browser.storage.session.get("sessionData");
     const currentTimeInMs = Date.now();
+
     // Check if session exists and is still valid
     if (sessionData && sessionData.timestamp != null) {
       const lastMs = Number(sessionData.timestamp);
       const durationInMin = (currentTimeInMs - lastMs) / 60000;
+
       // Check if last update lays past the session expiration threshold
       if (durationInMin > SESSION_EXPIRATION_IN_MIN) {
         // Clear old session id to start a new session
@@ -72,6 +88,7 @@ class Analytics {
         await browser.storage.session.set({ sessionData });
       }
     }
+
     if (!sessionData) {
       // Create and store a new session
       sessionData = {
@@ -80,7 +97,12 @@ class Analytics {
       };
       await browser.storage.session.set({ sessionData });
     }
+
     return sessionData.session_id;
+  }
+
+  getRequestUrl() {
+    return `${this.endpoint}?measurement_id=${MEASUREMENT_ID}&api_secret=${API_SECRET}`;
   }
 
   // Fires an event with optional params. Event names must only include letters and underscores.
@@ -90,37 +112,55 @@ class Analytics {
     }
 
     const payload: GaEventParams = { ...params };
-    // Configure session id and engagement time if not present, for more details see:
-    // https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag#recommended_parameters_for_reports
+
+    // Configure session id and engagement time if not present
     if (!payload.session_id) {
       payload.session_id = await this.getOrCreateSessionId();
     }
+
     if (!payload.engagement_time_msec) {
       payload.engagement_time_msec = DEFAULT_ENGAGEMENT_TIME_MSEC;
     }
 
-    try {
-      const response = await fetch(
-        `${
-          this.debug ? GA_DEBUG_ENDPOINT : GA_ENDPOINT
-        }?measurement_id=${MEASUREMENT_ID}&api_secret=${API_SECRET}`,
+    const requestBody: GaRequestBody = {
+      client_id: await this.getOrCreateClientId(),
+      events: [
         {
-          method: "POST",
-          body: JSON.stringify({
-            client_id: await this.getOrCreateClientId(),
-            events: [
-              {
-                name,
-                params: payload,
-              },
-            ],
-          }),
+          name,
+          params: payload,
         },
-      );
-      if (!this.debug) {
+      ],
+    };
+
+    const url = this.getRequestUrl();
+
+    try {
+      if (this.debug) {
+        console.groupCollapsed("[Analytics MOCK]");
+        console.log("endpoint:", url);
+        console.log("event:", name);
+        console.log("payload:", requestBody);
+        console.groupEnd();
         return;
       }
-      console.log(await response.text());
+
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      const responseText = await response.text();
+
+      if (!response.ok) {
+        console.error("Google Analytics request failed", {
+          status: response.status,
+          statusText: response.statusText,
+          body: responseText,
+        });
+      }
     } catch (e) {
       console.error("Google Analytics request failed with an exception", e);
     }
@@ -145,12 +185,11 @@ class Analytics {
     additionalParams: GaEventParams = {},
   ) {
     // Note: 'error' is a reserved event name and cannot be used
-    // see https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag#reserved_names
     return this.fireEvent("extension_error", {
       ...error,
       ...additionalParams,
     });
   }
 }
-
-export default new Analytics();
+const isDev = import.meta.env.MODE === "development";
+export default new Analytics(isDev);

--- a/apps/extension/src/services/google-analytics.service.ts
+++ b/apps/extension/src/services/google-analytics.service.ts
@@ -1,0 +1,156 @@
+import browser from "webextension-polyfill";
+
+const GA_ENDPOINT = "https://www.google-analytics.com/mp/collect";
+const GA_DEBUG_ENDPOINT = "https://www.google-analytics.com/debug/mp/collect";
+
+// Get via https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag#recommended_parameters_for_reports
+const MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID as
+  | string
+  | undefined;
+const API_SECRET = import.meta.env.VITE_GA_API_SECRET as string | undefined;
+const DEFAULT_ENGAGEMENT_TIME_MSEC = 100;
+
+// Duration of inactivity after which a new session is created
+const SESSION_EXPIRATION_IN_MIN = 30;
+
+type GaEventParams = Record<string, string | number | undefined>;
+
+class Analytics {
+  debug: boolean;
+
+  constructor(debug = false) {
+    this.debug = debug;
+  }
+
+  get isConfigured(): boolean {
+    return Boolean(MEASUREMENT_ID && API_SECRET);
+  }
+
+  getRandomId() {
+    const digits = "123456789".split("");
+    let result = "";
+
+    for (let i = 0; i < 10; i++) {
+      result += digits[Math.floor(Math.random() * 9)];
+    }
+
+    return result;
+  }
+
+  // Returns the client id, or creates a new one if one doesn't exist.
+  // Stores client id in local storage to keep the same client id as long as
+  // the extension is installed.
+  async getOrCreateClientId() {
+    let { clientId } = await chrome.storage.local.get("clientId");
+    if (!clientId) {
+      // Generate a unique client ID, the actual value is not relevant. We use
+      // the <number>.<number> format since this is typical for GA client IDs.
+      const unixTimestampSeconds = Math.floor(new Date().getTime() / 1000);
+      clientId = `${this.getRandomId()}.${unixTimestampSeconds}`;
+      await chrome.storage.local.set({ clientId });
+    }
+    return clientId;
+  }
+
+  // Returns the current session id, or creates a new one if one doesn't exist or
+  // the previous one has expired.
+  async getOrCreateSessionId() {
+    // Use storage.session because it is only in memory
+    let { sessionData } = await browser.storage.session.get("sessionData");
+    const currentTimeInMs = Date.now();
+    // Check if session exists and is still valid
+    if (sessionData && sessionData.timestamp != null) {
+      const lastMs = Number(sessionData.timestamp);
+      const durationInMin = (currentTimeInMs - lastMs) / 60000;
+      // Check if last update lays past the session expiration threshold
+      if (durationInMin > SESSION_EXPIRATION_IN_MIN) {
+        // Clear old session id to start a new session
+        sessionData = null;
+      } else {
+        // Update timestamp to keep session alive
+        sessionData.timestamp = currentTimeInMs;
+        await browser.storage.session.set({ sessionData });
+      }
+    }
+    if (!sessionData) {
+      // Create and store a new session
+      sessionData = {
+        session_id: currentTimeInMs.toString(),
+        timestamp: currentTimeInMs,
+      };
+      await browser.storage.session.set({ sessionData });
+    }
+    return sessionData.session_id;
+  }
+
+  // Fires an event with optional params. Event names must only include letters and underscores.
+  async fireEvent(name: string, params: GaEventParams = {}) {
+    if (!this.isConfigured) {
+      return;
+    }
+
+    const payload: GaEventParams = { ...params };
+    // Configure session id and engagement time if not present, for more details see:
+    // https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag#recommended_parameters_for_reports
+    if (!payload.session_id) {
+      payload.session_id = await this.getOrCreateSessionId();
+    }
+    if (!payload.engagement_time_msec) {
+      payload.engagement_time_msec = DEFAULT_ENGAGEMENT_TIME_MSEC;
+    }
+
+    try {
+      const response = await fetch(
+        `${
+          this.debug ? GA_DEBUG_ENDPOINT : GA_ENDPOINT
+        }?measurement_id=${MEASUREMENT_ID}&api_secret=${API_SECRET}`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            client_id: await this.getOrCreateClientId(),
+            events: [
+              {
+                name,
+                params: payload,
+              },
+            ],
+          }),
+        },
+      );
+      if (!this.debug) {
+        return;
+      }
+      console.log(await response.text());
+    } catch (e) {
+      console.error("Google Analytics request failed with an exception", e);
+    }
+  }
+
+  // Fire a page view event.
+  async firePageViewEvent(
+    pageTitle: string,
+    pageLocation: string,
+    additionalParams: GaEventParams = {},
+  ) {
+    return this.fireEvent("page_view", {
+      page_title: pageTitle,
+      page_location: pageLocation,
+      ...additionalParams,
+    });
+  }
+
+  // Fire an error event.
+  async fireErrorEvent(
+    error: GaEventParams,
+    additionalParams: GaEventParams = {},
+  ) {
+    // Note: 'error' is a reserved event name and cannot be used
+    // see https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag#reserved_names
+    return this.fireEvent("extension_error", {
+      ...error,
+      ...additionalParams,
+    });
+  }
+}
+
+export default new Analytics();

--- a/apps/extension/src/side-panel/SidePanel.tsx
+++ b/apps/extension/src/side-panel/SidePanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import DatePicker from "@/components/DatePicker";
 import { NAVIGATION_TAB } from "@/const/navigation.const";
@@ -10,12 +10,27 @@ import NavigationTabs from "@/features/layout/components/NavigationTabs";
 import PageContent from "@/features/layout/components/PageContent";
 import PageHeader from "@/features/layout/components/PageHeader";
 import SettingView from "@/features/setting/components/SettingView";
+import analytics from "@/services/google-analytics.service";
 
 export function SidePanel() {
   const [activeTab, setActiveTab] = useState<string>(NAVIGATION_TAB.ANALYSIS);
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(
     new Date(),
   );
+  const hasLoggedPanelOpen = useRef(false);
+
+  useEffect(() => {
+    if (hasLoggedPanelOpen.current) return;
+    hasLoggedPanelOpen.current = true;
+    void analytics.firePageViewEvent(
+      "Retoday Side Panel",
+      typeof window !== "undefined" ? window.location.href : "",
+    );
+  }, []);
+
+  useEffect(() => {
+    void analytics.fireEvent("side_panel_tab_view", { tab: activeTab });
+  }, [activeTab]);
 
   return (
     <div className="flex h-full flex-col">

--- a/turbo.json
+++ b/turbo.json
@@ -5,18 +5,22 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"],
+      "env": ["MODE"]
     },
     "lint": {
       "dependsOn": ["^lint"],
-      "outputs": []
+      "outputs": [],
+      "env": ["MODE"]
     },
     "check-types": {
-      "dependsOn": ["^check-types"]
+      "dependsOn": ["^check-types"],
+      "env": ["MODE"]
     },
     "dev": {
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      "env": ["MODE"]
     }
   }
 }


### PR DESCRIPTION
## 작업 내용

- Chrome Extension 환경에서 GA4(Google Analytics 4) 기반 이벤트 수집 구조를 구축
- 각 영역별 사용자 행동 데이터를 추적할 수 있도록 로직을 추가

https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/tutorial.google-analytics 

Google Chrome 공식 샘플 및 기존 GA4 연동 사례를 참고하여, 확장 프로그램 구조(Background / Content / Side Panel)에 맞게 이벤트를 분리 설계했습니다.

## 작업 목적
- Chrome Extension 내 사용자 행동 데이터를 일관된 기준으로 수집
- Background / Content / UI 간 역할을 분리하여 확장 가능한 이벤트 구조 설계

영역 | 이벤트 | 설명
-- | -- | --
Background | extension_lifecycle | onInstalled — reason, 있으면 previous_version
Background | content_session_tracked | PAGE_VISITED가 제외 도메인이 아니고 세션 저장된 뒤, host만 전달
Background | login | Google OAuth로 토큰 저장 직후 method: google
Content | page_view (기본 GA) | firePageViewEvent — page_location은 origin만 (https://host/)
Side panel | page_view | 최초 1회 — 제목 Retoday Side Panel, page_location은 확장 페이지 URL
Side panel | side_panel_tab_view | analysis / ai-recap / settings 전환마다 tab 파라미터


### 스크린샷 (선택)
