### PR TITLE
chore: 공용 hooks/utils 패키지 초기 구성

### DIFF
--- a/packages/hooks/eslint.config.mjs
+++ b/packages/hooks/eslint.config.mjs
@@ -1,0 +1,3 @@
+import config from "@recap/eslint-config/vite";
+
+export default config;

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@recap/hooks",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "eslint . --max-warnings 0",
+    "check-types": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@recap/eslint-config": "workspace:*",
+    "@recap/typescript-config": "workspace:*",
+    "@types/node": "^22.15.3",
+    "@types/react": "19.2.2",
+    "eslint": "^9.39.1",
+    "typescript": "5.9.2"
+  },
+  "dependencies": {
+    "react": "^19.2.0"
+  }
+}

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./use-boolean";

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./use-boolean";
+export * from "./use-uncontrolled";

--- a/packages/hooks/src/use-boolean.ts
+++ b/packages/hooks/src/use-boolean.ts
@@ -1,0 +1,40 @@
+import { useCallback, useState } from "react";
+
+type UseBooleanReturn = {
+  value: boolean;
+  setValue: (next: boolean) => void;
+  setTrue: () => void;
+  setFalse: () => void;
+  toggle: () => void;
+};
+
+const useBoolean = (initialValue = false): UseBooleanReturn => {
+  const [value, setInternalValue] = useState(initialValue);
+
+  const setValue = useCallback((next: boolean) => {
+    setInternalValue(next);
+  }, []);
+
+  const setTrue = useCallback(() => {
+    setInternalValue(true);
+  }, []);
+
+  const setFalse = useCallback(() => {
+    setInternalValue(false);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setInternalValue((prev) => !prev);
+  }, []);
+
+  return {
+    value,
+    setValue,
+    setTrue,
+    setFalse,
+    toggle,
+  };
+};
+
+export { useBoolean };
+export type { UseBooleanReturn };

--- a/packages/hooks/src/use-uncontrolled.ts
+++ b/packages/hooks/src/use-uncontrolled.ts
@@ -1,0 +1,51 @@
+import { useState } from "react";
+
+export interface UseUncontrolledOptions<T> {
+  /** Value for controlled state */
+  value?: T;
+
+  /** Initial value for uncontrolled state */
+  defaultValue?: T;
+
+  /** Final value for uncontrolled state when value and defaultValue are not provided */
+  finalValue?: T;
+
+  /** Controlled state onChange handler */
+  onChange?: (value: T, ...payload: unknown[]) => void;
+}
+
+export type UseUncontrolledReturnValue<T> = [
+  /** Current value */
+  T,
+
+  /** Handler to update the state, passes `value` and `payload` to `onChange` */
+  (value: T, ...payload: unknown[]) => void,
+
+  /** True if the state is controlled, false if uncontrolled */
+  boolean,
+];
+
+export function useUncontrolled<T>({
+  value,
+  defaultValue,
+  finalValue,
+  onChange = () => {},
+}: UseUncontrolledOptions<T>): UseUncontrolledReturnValue<T> {
+  const [uncontrolledValue, setUncontrolledValue] = useState(
+    defaultValue !== undefined ? defaultValue : finalValue,
+  );
+
+  const handleUncontrolledChange = (val: T, ...payload: unknown[]) => {
+    setUncontrolledValue(val);
+    onChange?.(val, ...payload);
+  };
+
+  if (value !== undefined) {
+    return [value as T, onChange, true];
+  }
+
+  return [uncontrolledValue as T, handleUncontrolledChange, false];
+}
+
+export type Options<T> = UseUncontrolledOptions<T>;
+export type ReturnValue<T> = UseUncontrolledReturnValue<T>;

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@recap/typescript-config/react-library",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": ["src", "**/*.ts", "**/*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/utils/eslint.config.mjs
+++ b/packages/utils/eslint.config.mjs
@@ -1,0 +1,3 @@
+import config from "@recap/eslint-config/base";
+
+export default config;

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@recap/utils",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "eslint . --max-warnings 0",
+    "check-types": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@recap/eslint-config": "workspace:*",
+    "@recap/typescript-config": "workspace:*",
+    "@types/node": "^22.15.3",
+    "eslint": "^9.39.1",
+    "typescript": "5.9.2"
+  },
+  "dependencies": {
+    "dayjs": "^1.11.19"
+  }
+}

--- a/packages/utils/src/dayjs/index.ts
+++ b/packages/utils/src/dayjs/index.ts
@@ -1,0 +1,7 @@
+import dayjs from "dayjs";
+
+const formatDate = (input: string | Date, pattern = "YYYY-MM-DD HH:mm") => {
+  return dayjs(input).format(pattern);
+};
+
+export { dayjs, formatDate };

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./dayjs";

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@recap/typescript-config/base",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": ["src", "**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,31 @@ importers:
         specifier: ^8.0.0
         version: 8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2)
 
+  packages/hooks:
+    dependencies:
+      react:
+        specifier: ^19.2.0
+        version: 19.2.0
+    devDependencies:
+      '@recap/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@recap/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^22.15.3
+        version: 22.15.3
+      '@types/react':
+        specifier: 19.2.2
+        version: 19.2.2
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.6.1)
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+
   packages/i18n:
     dependencies:
       i18next:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,28 @@ importers:
         specifier: 5.9.2
         version: 5.9.2
 
+  packages/utils:
+    dependencies:
+      dayjs:
+        specifier: ^1.11.19
+        version: 1.11.19
+    devDependencies:
+      '@recap/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@recap/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^22.15.3
+        version: 22.15.3
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.6.1)
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+
 packages:
 
   '@alloc/quick-lru@5.2.0':


### PR DESCRIPTION
## 작업 내용

공용 훅과 유틸을 모노레포 패키지로 분리하기 위해 `packages/hooks`, `packages/utils` 패키지를 새로 추가했습니다.

- `packages/hooks` 공용 패키지 추가
  - `useBoolean` 훅 구현
  - `useUncontrolled` 훅 구현

- `packages/utils` 공용 패키지 추가
  - `dayjs` 유틸 진입점 구성
  - `src/dayjs/index.ts` 추가

- 신규 패키지 기본 설정 추가
  - `package.json`
  - `tsconfig.json`
  - `eslint.config.mjs`

- 새 패키지 추가에 따라 `pnpm-lock.yaml` 갱신

## 작업 목적

앱/웹 전반에서 재사용 가능한 훅과 유틸을 공용 패키지로 분리하여 중복 구현을 줄이고 유지보수성을 높이기 위함입니다.

또한 공용 모듈의 초기 스캐폴딩을 먼저 구성해, 이후 공통 훅/유틸 확장을 빠르게 진행할 수 있는 기반을 마련했습니다.

## 스크린샷

없음