### PR TITLE
feat(web): 웹 다국어 지원 및 dayjs 공통 유틸 적용 

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,8 +1,9 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import { DEFAULT_LANGUAGE } from "@recap/i18n";
 
-import { ReactQueryProvider } from "@/app/providers";
+import { LanguageProvider, ReactQueryProvider } from "@/app/providers";
 import { AuthProvider } from "@/entities/auth/ui";
 import { MainHeader, MainLayout } from "@/widgets/layout/ui";
 
@@ -46,17 +47,23 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ko" className={ibmPlexSansKR.variable}>
-      <body className="mx-auto max-w-7xl bg-gray-100">
+    <html
+      lang={DEFAULT_LANGUAGE}
+      className={`${ibmPlexSansKR.variable} flex min-h-screen justify-center bg-gray-100`}
+      suppressHydrationWarning
+    >
+      <body className="min-h-screen w-[min(100%,80rem)] bg-gray-100">
         <ReactQueryProvider>
-          <AuthProvider>
-            <MainLayout>
-              <Suspense>
-                <MainHeader />
-              </Suspense>
-              {children}
-            </MainLayout>
-          </AuthProvider>
+          <LanguageProvider>
+            <AuthProvider>
+              <MainLayout>
+                <Suspense>
+                  <MainHeader />
+                </Suspense>
+                {children}
+              </MainLayout>
+            </AuthProvider>
+          </LanguageProvider>
         </ReactQueryProvider>
       </body>
     </html>

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -10,7 +10,12 @@ const appDir = path.dirname(fileURLToPath(import.meta.url));
 const monorepoRoot = path.resolve(appDir, "../..");
 
 const nextConfig = {
-  transpilePackages: ["@recap/ui", "@recap/tokens"],
+  transpilePackages: [
+    "@recap/ui",
+    "@recap/tokens",
+    "@recap/i18n",
+    "@recap/hooks",
+  ],
 
   outputFileTracingRoot: monorepoRoot,
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,17 +13,18 @@
     "check-types": "next typegen && tsc --noEmit"
   },
   "dependencies": {
+    "@recap/i18n": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "next": "16.1.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@recap/api": "workspace:*",
     "@recap/eslint-config": "workspace:*",
     "@recap/hooks": "workspace:*",
-    "@recap/i18n": "workspace:*",
     "@recap/react-query": "workspace:*",
     "@recap/tailwind-config": "workspace:*",
     "@recap/tokens": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,8 @@
   "devDependencies": {
     "@recap/api": "workspace:*",
     "@recap/eslint-config": "workspace:*",
+    "@recap/hooks": "workspace:*",
+    "@recap/i18n": "workspace:*",
     "@recap/react-query": "workspace:*",
     "@recap/tailwind-config": "workspace:*",
     "@recap/tokens": "workspace:*",

--- a/apps/web/src/app/providers/index.ts
+++ b/apps/web/src/app/providers/index.ts
@@ -1,1 +1,2 @@
+export { LanguageProvider } from "./language-provider";
 export { default as ReactQueryProvider } from "./react-query-provider";

--- a/apps/web/src/app/providers/language-provider/LanguageProvider.tsx
+++ b/apps/web/src/app/providers/language-provider/LanguageProvider.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import type { PropsWithChildren } from "react";
+import { I18nProvider } from "@recap/i18n";
+
+import { useLanguageStore } from "@/entities/language";
+
+const LanguageProvider = ({ children }: PropsWithChildren) => {
+  const language = useLanguageStore((s) => s.localize);
+
+  return <I18nProvider lng={language}>{children}</I18nProvider>;
+};
+
+export default LanguageProvider;

--- a/apps/web/src/app/providers/language-provider/index.ts
+++ b/apps/web/src/app/providers/language-provider/index.ts
@@ -1,0 +1,1 @@
+export { default as LanguageProvider } from "./LanguageProvider";

--- a/apps/web/src/entities/language/index.ts
+++ b/apps/web/src/entities/language/index.ts
@@ -1,0 +1,7 @@
+export {
+  initialLanguageState,
+  type LanguageState,
+  type LanguageStoreSchema,
+  useLanguageStore,
+} from "./model/language.store";
+export { default as LanguageSelect } from "./ui/LanguageSelect";

--- a/apps/web/src/entities/language/model/language.store.ts
+++ b/apps/web/src/entities/language/model/language.store.ts
@@ -1,0 +1,43 @@
+import { DEFAULT_LANGUAGE, type LanguageType } from "@recap/i18n";
+import { create } from "zustand";
+import {
+  createJSONStorage,
+  persist,
+  type StateStorage,
+} from "zustand/middleware";
+
+const noopStorage: StateStorage = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+};
+
+export interface LanguageState {
+  localize: LanguageType;
+}
+
+export const initialLanguageState: LanguageState = {
+  localize: DEFAULT_LANGUAGE,
+};
+
+type LanguageActions = {
+  setLanguage: (payload: LanguageType) => void;
+};
+
+export type LanguageStoreSchema = LanguageState & LanguageActions;
+
+export const useLanguageStore = create<LanguageStoreSchema>()(
+  persist(
+    (set) => ({
+      ...initialLanguageState,
+      setLanguage: (payload) => set({ localize: payload }),
+    }),
+    {
+      name: "recap-language-picker",
+      storage: createJSONStorage(() =>
+        typeof window !== "undefined" ? window.localStorage : noopStorage,
+      ),
+      partialize: (state) => ({ localize: state.localize }),
+    },
+  ),
+);

--- a/apps/web/src/entities/language/ui/LanguageSelect.tsx
+++ b/apps/web/src/entities/language/ui/LanguageSelect.tsx
@@ -5,6 +5,7 @@ import {
   DEFAULT_LANGUAGE,
   type LanguageType,
   SUPPORTED_LANGUAGES,
+  useLocale,
 } from "@recap/i18n";
 import {
   Select,
@@ -42,6 +43,7 @@ const LanguageSelect = ({
   onValueChange,
   disabled,
 }: LanguageSelectProps) => {
+  const { t } = useLocale("settings");
   const [selectedLanguage, setSelectedLanguage] = useUncontrolled<LanguageType>(
     {
       value,
@@ -62,7 +64,7 @@ const LanguageSelect = ({
       disabled={disabled}
     >
       <SelectTrigger className={className}>
-        <SelectValue placeholder="선택된 언어" />
+        <SelectValue placeholder={t("language.selectPlaceholder")} />
       </SelectTrigger>
 
       <SelectContent>

--- a/apps/web/src/entities/language/ui/LanguageSelect.tsx
+++ b/apps/web/src/entities/language/ui/LanguageSelect.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useUncontrolled } from "@recap/hooks";
+import {
+  DEFAULT_LANGUAGE,
+  type LanguageType,
+  SUPPORTED_LANGUAGES,
+} from "@recap/i18n";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@recap/ui";
+
+const LANGUAGE_LABEL: Record<LanguageType, string> = {
+  ko: "한국어",
+  en: "English",
+  ja: "日本語",
+};
+
+type LanguageSelectProps = {
+  className?: string;
+
+  /** controlled mode */
+  value?: LanguageType;
+
+  /** uncontrolled mode initial value */
+  defaultValue?: LanguageType;
+
+  /** controlled/uncontrolled 공통 change callback */
+  onValueChange?: (next: LanguageType) => void;
+
+  disabled?: boolean;
+};
+
+const LanguageSelect = ({
+  className,
+  value,
+  defaultValue,
+  onValueChange,
+  disabled,
+}: LanguageSelectProps) => {
+  const [selectedLanguage, setSelectedLanguage] = useUncontrolled<LanguageType>(
+    {
+      value,
+      defaultValue,
+      finalValue: DEFAULT_LANGUAGE,
+      onChange: onValueChange,
+    },
+  );
+
+  const handleChange = (next: string) => {
+    setSelectedLanguage(next as LanguageType);
+  };
+
+  return (
+    <Select
+      value={selectedLanguage}
+      onValueChange={handleChange}
+      disabled={disabled}
+    >
+      <SelectTrigger className={className}>
+        <SelectValue placeholder="선택된 언어" />
+      </SelectTrigger>
+
+      <SelectContent>
+        {SUPPORTED_LANGUAGES.map((lng) => (
+          <SelectItem key={lng} value={lng}>
+            {LANGUAGE_LABEL[lng]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};
+
+export default LanguageSelect;

--- a/apps/web/src/entities/language/ui/index.ts
+++ b/apps/web/src/entities/language/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as LanguageSelect } from "./LanguageSelect";

--- a/apps/web/src/features/ai-recap/lib/format-date.ts
+++ b/apps/web/src/features/ai-recap/lib/format-date.ts
@@ -1,0 +1,34 @@
+import type { TFunction } from "@recap/i18n";
+import { formatDuration } from "@recap/utils";
+
+export const formatScreenTime = (tc: TFunction, totalMinutes: number) => {
+  if (totalMinutes <= 0) return "-";
+  return formatDuration(totalMinutes * 60, tc);
+};
+
+export const formatMeridiemTime = (t: TFunction, value: Date) => {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) return null;
+
+  const hour = value.getHours();
+  const minute = value.getMinutes();
+  const meridiem = hour < 12 ? t("meridiemAm") : t("meridiemPm");
+  const displayHour = hour % 12 === 0 ? 12 : hour % 12;
+
+  if (minute === 0) {
+    return `${displayHour}${meridiem}`;
+  }
+
+  return `${displayHour}:${String(minute).padStart(2, "0")}${meridiem}`;
+};
+
+export const formatMeasuredRange = (
+  t: TFunction,
+  startedAt: Date,
+  closedAt: Date,
+) => {
+  const started = formatMeridiemTime(t, startedAt);
+  const closed = formatMeridiemTime(t, closedAt);
+
+  if (!started || !closed) return "-";
+  return `${started} - ${closed}`;
+};

--- a/apps/web/src/features/ai-recap/ui/RecapSummary.tsx
+++ b/apps/web/src/features/ai-recap/ui/RecapSummary.tsx
@@ -1,44 +1,20 @@
-import Image from "next/image";
+"use client";
 
+import Image from "next/image";
+import { useLocale } from "@recap/i18n";
+
+import {
+  formatMeasuredRange,
+  formatScreenTime,
+} from "@/features/ai-recap/lib/format-date";
 import type { NormalizedRecap } from "@/features/ai-recap/model/recap.type";
 import AIRecapIcon from "@/shared/assets/icons/recap-ai.svg";
 import RecapImg from "@/shared/assets/img/recap-1.png";
 
-const formatScreenTime = (totalMinutes: number) => {
-  if (totalMinutes <= 0) return "-";
-
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-
-  if (hours <= 0) return `${minutes}분`;
-  if (minutes <= 0) return `${hours}시간`;
-  return `${hours}시간 ${minutes}분`;
-};
-
-const formatMeridiemTime = (value: Date) => {
-  if (!(value instanceof Date) || Number.isNaN(value.getTime())) return null;
-
-  const hour = value.getHours();
-  const minute = value.getMinutes();
-  const meridiem = hour < 12 ? "am" : "pm";
-  const displayHour = hour % 12 === 0 ? 12 : hour % 12;
-
-  if (minute === 0) {
-    return `${displayHour}${meridiem}`;
-  }
-
-  return `${displayHour}:${String(minute).padStart(2, "0")}${meridiem}`;
-};
-
-const formatMeasuredRange = (startedAt: Date, closedAt: Date) => {
-  const started = formatMeridiemTime(startedAt);
-  const closed = formatMeridiemTime(closedAt);
-
-  if (!started || !closed) return "-";
-  return `${started} - ${closed}`;
-};
-
 const RecapSummary = ({ recap }: { recap: NormalizedRecap }) => {
+  const { t } = useLocale("ai-recap");
+  const { t: tc } = useLocale("common");
+
   const sections = recap.sections;
   const totalMinutes = recap.timelines.reduce(
     (sum, timeline) => sum + timeline.durationMinutes,
@@ -53,24 +29,30 @@ const RecapSummary = ({ recap }: { recap: NormalizedRecap }) => {
       <div className="p-10">
         <div className="flex items-end justify-between">
           <div className="space-y-2">
-            <p className="text-heading-md text-blue-400">Today’s Recap</p>
+            <p className="text-heading-md text-blue-400">
+              {t("screenTime.todayRecapTitle")}
+            </p>
             <h2 className="text-display-2 text-gray-900">{title}</h2>
           </div>
 
           <div className="flex items-center gap-4">
             <div className="w-42 space-y-1">
-              <p className="text-subtitle-2-rg text-gray-500">총 스크린타임</p>
+              <p className="text-subtitle-2-rg text-gray-500">
+                {t("todayRecap.totalScreenTimeLabel")}
+              </p>
               <p className="text-heading-rg text-gray-900">
-                {formatScreenTime(totalMinutes)}
+                {formatScreenTime(tc, totalMinutes)}
               </p>
             </div>
 
             <div className="h-18 w-px bg-gray-200" />
 
             <div className="w-42 space-y-1">
-              <p className="text-subtitle-2-rg text-gray-500">측정시간</p>
+              <p className="text-subtitle-2-rg text-gray-500">
+                {t("todayRecap.measurementTimeLabel")}
+              </p>
               <p className="text-heading-rg text-gray-900">
-                {formatMeasuredRange(recap.startedAt, recap.closedAt)}
+                {formatMeasuredRange(tc, recap.startedAt, recap.closedAt)}
               </p>
             </div>
           </div>
@@ -79,7 +61,9 @@ const RecapSummary = ({ recap }: { recap: NormalizedRecap }) => {
         <div className="mt-12 flex items-center gap-4 rounded-full bg-blue-50 px-2.5 py-2">
           <div className="flex items-center gap-2">
             <AIRecapIcon />
-            <p className="text-subtitle-1-sb text-gray-900">하루 요약</p>
+            <p className="text-subtitle-1-sb text-gray-900">
+              {t("todayRecap.dailySummaryLabel")}
+            </p>
           </div>
 
           <p className="text-body-2 text-gray-800">{summary}</p>
@@ -90,7 +74,9 @@ const RecapSummary = ({ recap }: { recap: NormalizedRecap }) => {
         <div>
           {sections.length === 0 ? (
             <div className="pt-6 pr-9 pb-13 pl-10">
-              <p className="text-body-1 text-gray-500">요약된 내용이 없어요</p>
+              <p className="text-body-1 text-gray-500">
+                {t("todayRecap.summarySectionsEmpty")}
+              </p>
             </div>
           ) : (
             sections.map((section, index) => (

--- a/apps/web/src/features/ai-recap/ui/Timeline.tsx
+++ b/apps/web/src/features/ai-recap/ui/Timeline.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import { useLocale } from "@recap/i18n";
+import { formatDuration } from "@recap/utils";
+
 import { useCustomScrollbar } from "@/features/ai-recap/lib/useCustomScrollbar";
 import type { NormalizedRecap } from "@/features/ai-recap/model/recap.type";
 import TimeLineBackgroundImg from "@/shared/assets/img/timeline-bg.png";
 
 const Timeline = ({ recap }: { recap: NormalizedRecap }) => {
+  const { t } = useLocale("ai-recap");
+  const { t: tc } = useLocale("common");
   const {
     scrollerRef,
     trackRef,
@@ -30,9 +35,11 @@ const Timeline = ({ recap }: { recap: NormalizedRecap }) => {
   return (
     <div className="relative flex gap-9 rounded-[1.25rem] bg-white px-9 py-8">
       <div className="max-w-57 space-y-2">
-        <p className="text-heading-rg text-gray-800">AI 타임라인</p>
+        <p className="text-heading-rg text-gray-800">
+          {t("todayRecap.aiTimelineTitle")}
+        </p>
         <h2 className="text-title-1 text-gray-900">
-          Retoday가 요약한 오늘 하루의 흐름
+          {t("todayRecap.aiTimelineSubtitle")}
         </h2>
       </div>
 
@@ -64,7 +71,7 @@ const Timeline = ({ recap }: { recap: NormalizedRecap }) => {
         >
           {recap.timelines.length === 0 ? (
             <div className="text-body-1 text-gray-500">
-              타임라인 데이터가 없어요
+              {t("todayRecap.timelineEmpty")}
             </div>
           ) : (
             <div className="relative ml-3.25 space-y-4">
@@ -88,7 +95,7 @@ const Timeline = ({ recap }: { recap: NormalizedRecap }) => {
 
                       <div className="flex items-center gap-2">
                         <p className="text-body-1 text-gray-500">
-                          {formatDuration(timeline.durationMinutes)}
+                          {formatDuration(timeline.durationMinutes * 60, tc)}
                         </p>
 
                         <div className="size-1 rounded-full bg-gray-200" />
@@ -110,12 +117,3 @@ const Timeline = ({ recap }: { recap: NormalizedRecap }) => {
 };
 
 export default Timeline;
-
-const formatDuration = (minutes: number) => {
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  const restMinutes = minutes % 60;
-
-  if (restMinutes === 0) return `${hours}h`;
-  return `${hours}h ${restMinutes}m`;
-};

--- a/apps/web/src/features/ai-recap/ui/TopVisitedTopics.tsx
+++ b/apps/web/src/features/ai-recap/ui/TopVisitedTopics.tsx
@@ -1,6 +1,12 @@
+"use client";
+
+import { useLocale } from "@recap/i18n";
+
 import type { NormalizedRecap } from "@/features/ai-recap/model/recap.type";
 
 const TopVisitedTopics = ({ recap }: { recap: NormalizedRecap }) => {
+  const { t } = useLocale("ai-recap");
+
   const topKeywords = recap.topics.slice(0, 3).map((topic) => topic.keyword);
   const topicCards = recap.topics.slice(0, 3);
   const keywordStyles = [
@@ -11,12 +17,16 @@ const TopVisitedTopics = ({ recap }: { recap: NormalizedRecap }) => {
 
   return (
     <div className="rounded-[1.25rem] bg-white px-9 py-8">
-      <p className="text-heading-rg text-gray-800">많이 둘러본 주제</p>
+      <p className="text-heading-rg text-gray-800">
+        {t("todayRecap.mostViewedTopicsTitle")}
+      </p>
 
       <div className="mt-6 grid h-74 grid-cols-4 gap-4">
         <div className="relative overflow-hidden rounded-[1.25rem] bg-blue-50 px-6.5 py-6">
           {topKeywords.length === 0 ? (
-            <p className="text-body-1 text-gray-500">주제 데이터가 없어요</p>
+            <p className="text-body-1 text-gray-500">
+              {t("todayRecap.topicsEmpty")}
+            </p>
           ) : (
             <>
               {topKeywords.map((keyword, index) => (
@@ -36,7 +46,7 @@ const TopVisitedTopics = ({ recap }: { recap: NormalizedRecap }) => {
               <div key={index} className="bg-gray-75 rounded-xl px-6.5 py-6">
                 <h3 className="text-heading-md text-gray-900">-</h3>
                 <p className="text-body-1 mt-4 whitespace-pre-line text-gray-500">
-                  주제 데이터가 없어요
+                  {t("todayRecap.topicsEmpty")}
                 </p>
               </div>
             ))

--- a/apps/web/src/features/analysis/model/screen-time-bar-data.ts
+++ b/apps/web/src/features/analysis/model/screen-time-bar-data.ts
@@ -1,0 +1,80 @@
+import type { TFunction } from "@recap/i18n";
+import type { WeeklyBarDatum } from "@recap/ui";
+import { formatTwoDigitNumber } from "@recap/utils";
+
+import { secondsToMinute } from "@/shared/lib/date/format-date";
+
+import type { ScreenTimeType } from "./get-screen-time.schema";
+
+export const SCREEN_TIME_BAR_WEEKDAY_KEYS = [
+  "sun",
+  "mon",
+  "tue",
+  "wed",
+  "thu",
+  "fri",
+  "sat",
+] as const;
+export function toDailyBarData(
+  screenTimes: ScreenTimeType[],
+  t: TFunction,
+): WeeklyBarDatum[] {
+  const blocks: WeeklyBarDatum[] = Array.from({ length: 12 }, (_, i) => {
+    const startHour = i * 2;
+    return {
+      key: `today-${startHour}`,
+      label: String(startHour),
+      subLabel: t("screenTime.dailyTimeSlotSubLabel", {
+        start: formatTwoDigitNumber(startHour),
+        end: formatTwoDigitNumber(startHour + 2),
+      }),
+      totalMinutes: 0,
+      avgMinutes: 0,
+    };
+  });
+
+  for (const st of screenTimes) {
+    const d = new Date(st.startedAt);
+    const hour = d.getHours();
+    const idx = Math.floor(hour / 2);
+    if (!blocks[idx]) continue;
+
+    blocks[idx].totalMinutes += secondsToMinute(st.stayDuration);
+  }
+
+  blocks.forEach((b) => {
+    b.avgMinutes = b.totalMinutes;
+  });
+  return blocks;
+}
+
+export function toWeeklyBarData(
+  screenTimes: ScreenTimeType[],
+  rangeLabel: string,
+  t: TFunction,
+): WeeklyBarDatum[] {
+  const labels = SCREEN_TIME_BAR_WEEKDAY_KEYS.map((k) =>
+    t(`screenTime.weekdayShort.${k}`),
+  );
+
+  const blocks: WeeklyBarDatum[] = labels.map((label, idx) => ({
+    key: `week-${idx}-${label}`,
+    label,
+    subLabel: rangeLabel,
+    totalMinutes: 0,
+    avgMinutes: 0,
+  }));
+
+  for (const st of screenTimes) {
+    const d = new Date(st.startedAt);
+    const day = d.getDay();
+    if (!blocks[day]) continue;
+
+    blocks[day].totalMinutes += secondsToMinute(st.stayDuration);
+  }
+
+  blocks.forEach((b) => {
+    b.avgMinutes = b.totalMinutes;
+  });
+  return blocks;
+}

--- a/apps/web/src/features/analysis/ui/CategoryAnalysis.tsx
+++ b/apps/web/src/features/analysis/ui/CategoryAnalysis.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import Image from "next/image";
+import { Trans, useLocale } from "@recap/i18n";
 import { Badge, cn } from "@recap/ui";
 import { useQuery } from "@tanstack/react-query";
 
@@ -9,6 +10,7 @@ import { analysisAPIService } from "@/features/analysis/api";
 import BubbleCloudFalling, {
   type BubbleDatum,
 } from "@/features/analysis/ui/BubbleCloud";
+import { formatSecondsToMinutes } from "@/shared/lib/date/format-date";
 
 type CategoryWebsite = {
   domain: string;
@@ -24,16 +26,6 @@ type CategoryItem = {
 
 const COLS = 2;
 
-const formatMinutesFromSeconds = (seconds: number) => {
-  const minutes = Math.max(0, Math.round(seconds / 60));
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
-
-  if (h <= 0) return `${m}분`;
-  if (m <= 0) return `${h}시간`;
-  return `${h}시간 ${m}분`;
-};
-
 const pickTopCategory = (list: CategoryItem[]) => {
   if (list.length === 0) return null;
   return [...list].sort(
@@ -42,6 +34,9 @@ const pickTopCategory = (list: CategoryItem[]) => {
 };
 
 const CategoryAnalysis = ({ date }: { date: string }) => {
+  const { t } = useLocale("analysis");
+  const { t: tc } = useLocale("common");
+
   const { data, isLoading } = useQuery({
     queryKey: ["getCategoryAnalysis", date],
     queryFn: () => analysisAPIService.getCategoryAnalysis({ date }),
@@ -111,9 +106,9 @@ const CategoryAnalysis = ({ date }: { date: string }) => {
 
     return {
       category: served.top.categoryName,
-      duration: formatMinutesFromSeconds(served.top.stayDuration),
+      duration: formatSecondsToMinutes(served.top.stayDuration, tc),
     };
-  }, [isLoading, served.top]);
+  }, [isLoading, served.top, tc]);
 
   const isSingle = listRows.length === 1;
 
@@ -121,13 +116,22 @@ const CategoryAnalysis = ({ date }: { date: string }) => {
     <div className="flex rounded-[1.25rem] bg-white">
       <div className="w-full p-5 md:p-6 xl:p-10">
         <h2 className="text-heading-rg whitespace-nowrap text-gray-800">
-          카테고리별 분석
+          {t("category.title")}
         </h2>
 
         <h3 className="text-title-1 mt-2 whitespace-nowrap text-gray-900">
-          <span className="text-blue-400">{headerText.category}</span>에{" "}
-          <span className="text-blue-400">{headerText.duration}</span>{" "}
-          몰두했어요
+          <Trans
+            ns="analysis"
+            i18nKey="category.shoppingFocusSummary"
+            values={{
+              category: headerText.category,
+              time_spent: headerText.duration,
+            }}
+            components={{
+              category: <span className="text-blue-400" />,
+              time: <span className="text-blue-400" />,
+            }}
+          />
         </h3>
 
         <BubbleCloudFalling data={bubbleData} />
@@ -138,7 +142,7 @@ const CategoryAnalysis = ({ date }: { date: string }) => {
             className="cursor-pointer"
             onClick={() => setSelectedCategory("__ALL__")}
           >
-            전체
+            {t("category.filterAll")}
           </Badge>
 
           {served.categories.map((c) => (
@@ -158,7 +162,7 @@ const CategoryAnalysis = ({ date }: { date: string }) => {
         <div className="mt-5 grid grid-cols-1 gap-x-8 md:grid-cols-2">
           {isEmpty ? (
             <div className="text-body-1 text-gray-500">
-              분석 데이터가 없어요
+              {t("category.emptyState")}
             </div>
           ) : (
             listRows.map((row, idx) => {
@@ -186,7 +190,7 @@ const CategoryAnalysis = ({ date }: { date: string }) => {
                       {row.categoryName}
                     </p>
                     <p className="text-subtitle-2-rg whitespace-nowrap text-gray-800">
-                      {formatMinutesFromSeconds(row.stayDuration)}
+                      {formatSecondsToMinutes(row.stayDuration, tc)}
                     </p>
                   </div>
 

--- a/apps/web/src/features/analysis/ui/ScreenTime.tsx
+++ b/apps/web/src/features/analysis/ui/ScreenTime.tsx
@@ -2,34 +2,31 @@
 
 import { useMemo, useState } from "react";
 import Image, { type StaticImageData } from "next/image";
+import { useLocale } from "@recap/i18n";
 import { Badge, type WeeklyBarDatum } from "@recap/ui";
+import { dayjs, formatDuration } from "@recap/utils";
 import { useQuery } from "@tanstack/react-query";
 
 import { analysisAPIService } from "@/features/analysis/api";
-import type {
-  ScreenTimePeriodType,
-  ScreenTimeType,
-} from "@/features/analysis/model/get-screen-time.schema";
+import type { ScreenTimePeriodType } from "@/features/analysis/model/get-screen-time.schema";
+import {
+  toDailyBarData,
+  toWeeklyBarData,
+} from "@/features/analysis/model/screen-time-bar-data";
 import EmptyDayChartImg from "@/shared/assets/img/empty-day-chart.png";
 import EmptyWeekChartImg from "@/shared/assets/img/empty-week-chart.png";
+import { secondsToMinute } from "@/shared/lib/date/format-date";
 import ScreenTimeWeeklyBarChart from "@/shared/ui/ScreenTimeWeeklyBarChart";
 
-const EMPTY_ASSET: Record<
-  ScreenTimePeriodType,
-  { src: StaticImageData; alt: string }
-> = {
-  WEEKLY: {
-    src: EmptyWeekChartImg,
-    alt: "이번 주간에는 아직 누적된 활동이 보이지 않아요",
-  },
-  DAILY: {
-    src: EmptyDayChartImg,
-    alt: "이 날에는 누적된 활동이 없어요",
-  },
+const EMPTY_SRC: Record<ScreenTimePeriodType, StaticImageData> = {
+  WEEKLY: EmptyWeekChartImg,
+  DAILY: EmptyDayChartImg,
 };
 
 const ScreenTime = ({ date }: { date: string }) => {
   const [mode, setMode] = useState<ScreenTimePeriodType>("DAILY");
+  const { t } = useLocale("analysis");
+  const { t: tc } = useLocale("common");
 
   const { data } = useQuery({
     queryKey: ["getScreenTime", mode, date],
@@ -49,23 +46,28 @@ const ScreenTime = ({ date }: { date: string }) => {
       };
     }
 
-    const totalMinutes = secondsToMinutes(data.data.totalStayDuration);
+    const totalMinutes = secondsToMinute(data.data.totalStayDuration);
     const isEmpty = totalMinutes <= 0 || data.data.screenTimes.length === 0;
 
-    const rangeLabel = `${toMMDD(data.data.startedAt)} - ${toMMDD(data.data.endedAt)}`;
+    const rangeLabel = `${dayjs(data.data.startedAt).format("MM.DD")} - ${dayjs(data.data.endedAt).format("MM.DD")}`;
 
     const chartData =
       data.data.period === "DAILY"
-        ? toDailyBarData(data.data.screenTimes)
-        : toWeeklyBarData(data.data.screenTimes, rangeLabel);
+        ? toDailyBarData(data.data.screenTimes, t)
+        : toWeeklyBarData(data.data.screenTimes, rangeLabel, t);
 
     const summaryText =
       data.data.period === "DAILY"
-        ? formatMinutes(totalMinutes)
-        : formatMinutes(Math.round(totalMinutes / 7));
+        ? formatDuration(totalMinutes * 60, tc)
+        : formatDuration(Math.round(totalMinutes / 7) * 60, tc);
 
     return { chartData, summaryText, isEmpty };
-  }, [data]);
+  }, [data, t, tc]);
+
+  const emptyAlt =
+    mode === "WEEKLY"
+      ? t("screenTime.emptyWeeklyChartAlt")
+      : t("screenTime.emptyDailyChartAlt");
 
   return (
     <div className="flex flex-col rounded-[1.25rem] bg-white xl:flex-row">
@@ -73,7 +75,9 @@ const ScreenTime = ({ date }: { date: string }) => {
         <div className="flex items-start justify-between gap-4">
           <div>
             <h2 className="text-heading-rg whitespace-nowrap text-gray-800">
-              {mode === "WEEKLY" ? "이번주 평균 스크린타임" : "총 스크린타임"}
+              {mode === "WEEKLY"
+                ? t("screenTime.weeklyAverageTitle")
+                : t("screenTime.title")}
             </h2>
 
             <h3 className="text-title-1 mt-2 whitespace-nowrap text-gray-900">
@@ -87,7 +91,7 @@ const ScreenTime = ({ date }: { date: string }) => {
               className="cursor-pointer"
               onClick={() => setMode("DAILY")}
             >
-              오늘
+              {t("screenTime.buttonToday")}
             </Badge>
 
             <Badge
@@ -95,7 +99,7 @@ const ScreenTime = ({ date }: { date: string }) => {
               className="cursor-pointer"
               onClick={() => setMode("WEEKLY")}
             >
-              주간
+              {t("screenTime.buttonWeekly")}
             </Badge>
           </div>
         </div>
@@ -108,7 +112,7 @@ const ScreenTime = ({ date }: { date: string }) => {
             className="cursor-pointer"
             onClick={() => setMode("DAILY")}
           >
-            오늘
+            {t("screenTime.buttonToday")}
           </Badge>
 
           <Badge
@@ -116,7 +120,7 @@ const ScreenTime = ({ date }: { date: string }) => {
             className="cursor-pointer"
             onClick={() => setMode("WEEKLY")}
           >
-            주간
+            {t("screenTime.buttonWeekly")}
           </Badge>
         </div>
 
@@ -136,8 +140,8 @@ const ScreenTime = ({ date }: { date: string }) => {
             >
               <div className="absolute inset-0 bg-white" />
               <Image
-                src={EMPTY_ASSET[mode].src}
-                alt={EMPTY_ASSET[mode].alt}
+                src={EMPTY_SRC[mode]}
+                alt={emptyAlt}
                 fill
                 priority
                 sizes="(max-width: 1024px) 100vw, 900px"
@@ -152,74 +156,3 @@ const ScreenTime = ({ date }: { date: string }) => {
 };
 
 export default ScreenTime;
-
-const formatMinutes = (minutes: number) => {
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
-
-  if (h <= 0) return `${m}분`;
-  if (m <= 0) return `${h}시간`;
-  return `${h}시간 ${m}분`;
-};
-
-const toMMDD = (date: Date) => {
-  const mm = String(date.getMonth() + 1).padStart(2, "0");
-  const dd = String(date.getDate()).padStart(2, "0");
-  return `${mm}.${dd}`;
-};
-
-const secondsToMinutes = (seconds: number) =>
-  Math.max(0, Math.round(seconds / 60));
-
-const toDailyBarData = (screenTimes: ScreenTimeType[]): WeeklyBarDatum[] => {
-  const blocks: WeeklyBarDatum[] = Array.from({ length: 12 }, (_, i) => {
-    const startHour = i * 2;
-    return {
-      key: `today-${startHour}`,
-      label: String(startHour),
-      subLabel: `오늘 ${String(startHour).padStart(2, "0")}:00 - ${String(
-        startHour + 2,
-      ).padStart(2, "0")}:00`,
-      totalMinutes: 0,
-      avgMinutes: 0,
-    };
-  });
-
-  for (const t of screenTimes) {
-    const d = new Date(t.startedAt);
-    const hour = d.getHours();
-    const idx = Math.floor(hour / 2);
-    if (!blocks[idx]) continue;
-
-    blocks[idx].totalMinutes += secondsToMinutes(t.stayDuration);
-  }
-
-  blocks.forEach((b) => (b.avgMinutes = b.totalMinutes));
-  return blocks;
-};
-
-const toWeeklyBarData = (
-  screenTimes: ScreenTimeType[],
-  rangeLabel: string,
-): WeeklyBarDatum[] => {
-  const labels = ["일", "월", "화", "수", "목", "금", "토"];
-
-  const blocks: WeeklyBarDatum[] = labels.map((label, idx) => ({
-    key: `week-${idx}-${label}`,
-    label,
-    subLabel: rangeLabel,
-    totalMinutes: 0,
-    avgMinutes: 0,
-  }));
-
-  for (const t of screenTimes) {
-    const d = new Date(t.startedAt);
-    const day = d.getDay();
-    if (!blocks[day]) continue;
-
-    blocks[day].totalMinutes += secondsToMinutes(t.stayDuration);
-  }
-
-  blocks.forEach((b) => (b.avgMinutes = b.totalMinutes));
-  return blocks;
-};

--- a/apps/web/src/features/analysis/ui/TodayTimeThief.tsx
+++ b/apps/web/src/features/analysis/ui/TodayTimeThief.tsx
@@ -2,21 +2,13 @@
 
 import { useMemo } from "react";
 import Image from "next/image";
+import { useLocale } from "@recap/i18n";
 import { cn } from "@recap/ui";
 import { useQuery } from "@tanstack/react-query";
 
 import { analysisAPIService } from "@/features/analysis/api";
 import TimeThiefImg from "@/shared/assets/img/time-thief.png";
-
-const formatMinutesFromSeconds = (seconds: number) => {
-  const minutes = Math.max(0, Math.round(seconds / 60));
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
-
-  if (h <= 0) return `${m}분`;
-  if (m <= 0) return `${h}시간`;
-  return `${h}시간 ${m}분`;
-};
+import { formatSecondsToMinutes } from "@/shared/lib/date/format-date";
 
 const getHostLabel = (domain: string | null) => {
   if (!domain) return null;
@@ -28,6 +20,8 @@ const getHostLabel = (domain: string | null) => {
 };
 
 const TodayTimeThief = ({ date }: { date: string }) => {
+  const { t } = useLocale("analysis");
+  const { t: tc } = useLocale("common");
   const { data, isLoading } = useQuery({
     queryKey: ["getTopVisitedSite", date],
     queryFn: () => analysisAPIService.getLongestStayedWebsite({ date }),
@@ -48,21 +42,23 @@ const TodayTimeThief = ({ date }: { date: string }) => {
     return {
       isEmpty: false,
       title: getHostLabel(site.domain) ?? "-",
-      durationText: formatMinutesFromSeconds(site.stayDuration ?? 0),
+      durationText: formatSecondsToMinutes(site.stayDuration ?? 0, tc),
       faviconUrl: site.faviconUrl ?? null,
     };
-  }, [data]);
+  }, [data, tc]);
 
   return (
     <div className="overflow-hidden rounded-[1.25rem] bg-white">
       <div className="p-5 pb-0 md:p-6 md:pb-0 xl:p-10 xl:pb-0">
         <div className="flex items-center justify-between">
           <h2 className="text-heading-rg whitespace-nowrap text-gray-800">
-            오늘의 시간 도둑
+            {t("timeThief.title")}
           </h2>
 
           <p className="text-body-1 text-gray-500">
-            {isLoading || served.isEmpty ? "-" : `총 ${served.durationText}`}
+            {isLoading || served.isEmpty
+              ? "-"
+              : t("timeThief.totalLabel", { duration: served.durationText })}
           </p>
         </div>
 
@@ -77,7 +73,7 @@ const TodayTimeThief = ({ date }: { date: string }) => {
       <div className="relative h-48 w-full md:h-52 xl:h-54">
         <Image
           src={TimeThiefImg}
-          alt="img"
+          alt={t("timeThief.imageAlt")}
           fill
           className="object-cover"
           priority={false}

--- a/apps/web/src/features/analysis/ui/TopVisitedSites.tsx
+++ b/apps/web/src/features/analysis/ui/TopVisitedSites.tsx
@@ -2,25 +2,17 @@
 
 import { useMemo } from "react";
 import Image from "next/image";
+import { useLocale } from "@recap/i18n";
 import { useQuery } from "@tanstack/react-query";
 
 import { analysisAPIService } from "@/features/analysis/api";
+import { formatSecondsToMinutes } from "@/shared/lib/date/format-date";
 
 type WebsiteAnalysis = {
   domain: string;
   faviconUrl: string | null;
   visitCount: number;
   stayDuration: number;
-};
-
-const formatMinutesFromSeconds = (seconds: number) => {
-  const minutes = Math.max(0, Math.round(seconds / 60));
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
-
-  if (h <= 0) return `${m}분`;
-  if (m <= 0) return `${h}시간`;
-  return `${h}시간 ${m}분`;
 };
 
 const toDisplayUrl = (domain: string) => {
@@ -32,6 +24,8 @@ const toDisplayUrl = (domain: string) => {
 };
 
 const TopVisitedSites = ({ date }: { date: string }) => {
+  const { t } = useLocale("analysis");
+  const { t: tc } = useLocale("common");
   const { data, isLoading } = useQuery({
     queryKey: ["getFrequentlyVisitedWebSite", date, 10],
     queryFn: () =>
@@ -51,22 +45,22 @@ const TopVisitedSites = ({ date }: { date: string }) => {
     return top.map((it) => ({
       ...it,
       displayUrl: toDisplayUrl(it.domain),
-      durationText: formatMinutesFromSeconds(it.stayDuration ?? 0),
+      durationText: formatSecondsToMinutes(it.stayDuration ?? 0, tc),
     }));
-  }, [data]);
+  }, [data, tc]);
 
   const isEmpty = !isLoading && served.length === 0;
 
   return (
     <div className="rounded-[1.25rem] bg-white p-5 md:p-6 xl:p-10">
       <h2 className="text-heading-rg whitespace-nowrap text-gray-800">
-        자주 방문한 사이트
+        {t("frequentSites.title")}
       </h2>
 
       <div className="mt-5 flex flex-col gap-2 md:mt-6">
         {isEmpty ? (
           <div className="text-body-1 text-gray-500">
-            아직 기록된 방문 사이트가 없어요
+            {t("frequentSites.emptyState")}
           </div>
         ) : (
           served.map((it, idx) => (

--- a/apps/web/src/features/analysis/ui/WorkPattern.tsx
+++ b/apps/web/src/features/analysis/ui/WorkPattern.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { useLocale } from "@recap/i18n";
 import { useQuery } from "@tanstack/react-query";
 
 import { analysisAPIService } from "@/features/analysis/api";
@@ -27,6 +28,7 @@ const ITEMS_META: Array<{
 ];
 
 const WorkPattern = ({ date }: { date: string }) => {
+  const { t } = useLocale("analysis");
   const { data, isLoading, isError } = useQuery({
     queryKey: ["getWorkPattern", date],
     queryFn: () => analysisAPIService.getWorkPattern({ date }),
@@ -55,10 +57,10 @@ const WorkPattern = ({ date }: { date: string }) => {
     );
 
     const labelMap: Record<WorkPatternDayType, string> = {
-      DAWN: "야행성 작업자",
-      MORNING: "얼리버드 작업자",
-      DAYTIME: "주간 작업자",
-      EVENING: "저녁형 작업자",
+      DAWN: t("workPattern.labelDawn"),
+      MORNING: t("workPattern.labelMorning"),
+      DAYTIME: t("workPattern.labelDaytime"),
+      EVENING: t("workPattern.labelEvening"),
     };
 
     const title = total <= 0 ? "-" : labelMap[best.key];
@@ -68,12 +70,12 @@ const WorkPattern = ({ date }: { date: string }) => {
       title,
       items,
     };
-  }, [data]);
+  }, [data, t]);
 
   return (
     <div className="rounded-[1.25rem] bg-white p-5 md:p-6 xl:p-10">
       <h2 className="text-heading-rg whitespace-nowrap text-gray-800">
-        내 작업 패턴
+        {t("workPattern.title")}
       </h2>
 
       <h3 className="text-title-1 mt-2 whitespace-nowrap text-gray-900">

--- a/apps/web/src/features/login/ui/LoginBanner.tsx
+++ b/apps/web/src/features/login/ui/LoginBanner.tsx
@@ -1,9 +1,13 @@
+"use client";
+
+import { useLocale } from "@recap/i18n";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useAuth } from "@/entities/auth/ui";
 import LoginButton from "@/features/login/ui/LoginButton";
 
 const LoginBanner = () => {
+  const { t } = useLocale("settings");
   const { refreshAuth } = useAuth();
   const queryClient = useQueryClient();
 
@@ -18,7 +22,7 @@ const LoginBanner = () => {
     <div className="bg-blue-75 rounded-[1.25rem] px-5 py-5 md:px-6 md:py-6 xl:px-9 xl:py-8">
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-4">
         <h2 className="text-subtitle-1-sb md:text-display-3 leading-tight text-gray-800">
-          로그인하고 내 하루 기록을 확인해 보세요
+          {t("account.dailyRecordsPrompt")}
         </h2>
 
         <LoginButton
@@ -27,7 +31,7 @@ const LoginBanner = () => {
         />
       </div>
       <p className="text-body-2 md:text-heading-rg mt-2 text-gray-800">
-        지금 보이는 화면은 샘플데이터에요
+        {t("account.sampleDataCaption")}
       </p>
     </div>
   );

--- a/apps/web/src/features/login/ui/LoginButton.tsx
+++ b/apps/web/src/features/login/ui/LoginButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLocale } from "@recap/i18n";
 import { cn } from "@recap/ui";
 
 import { useGoogleTokenLogin } from "@/features/login/model/use-google-token-login";
@@ -15,6 +16,7 @@ const LoginButton = ({
   children?: React.ReactNode;
 }) => {
   const { ready, login } = useGoogleTokenLogin({ onLoginSuccess });
+  const { t } = useLocale("settings");
 
   return (
     <button
@@ -26,7 +28,7 @@ const LoginButton = ({
         className,
       )}
     >
-      {children ?? "로그인"}
+      {children ?? t("account.login")}
       <RightIcon />
     </button>
   );

--- a/apps/web/src/features/settings/ui/ExcludedDomainSection.tsx
+++ b/apps/web/src/features/settings/ui/ExcludedDomainSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { catchAPIError } from "@recap/api";
+import { useLocale } from "@recap/i18n";
 import { cn } from "@recap/ui";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -18,6 +19,7 @@ const ExcludedDomainSection = ({
   disabled = false,
   domains,
 }: ExcludedDomainSectionProps) => {
+  const { t } = useLocale("settings");
   const [domain, setDomain] = useState("");
 
   const { refreshAuth } = useAuth();
@@ -60,10 +62,12 @@ const ExcludedDomainSection = ({
         disabled && "pointer-events-none opacity-50",
       )}
     >
-      <h2 className="text-heading-rg text-gray-800">추적금지 도메인</h2>
+      <h2 className="text-heading-rg text-gray-800">
+        {t("untrackedDomains.title")}
+      </h2>
 
       <p className="text-body-1 mt-2 text-gray-900">
-        브라우저 사용 기록 집계에서 제외할 도메인을 관리합니다.
+        {t("untrackedDomains.description")}
       </p>
 
       <div className="mt-6 space-y-1">
@@ -78,7 +82,7 @@ const ExcludedDomainSection = ({
               className="text-body-1 text-[#ff4242]"
               onClick={() => handleDeleteDomain(excludedDomain)}
             >
-              삭제
+              {t("untrackedDomains.delete")}
             </button>
           </div>
         ))}
@@ -90,7 +94,7 @@ const ExcludedDomainSection = ({
           type="text"
           value={domain}
           onChange={(e) => setDomain(e.target.value)}
-          placeholder="도메인 입력 ( 예 : abc.com sample.kr)"
+          placeholder={t("untrackedDomains.domainInputPlaceholder")}
           disabled={disabled}
         />
 
@@ -102,7 +106,7 @@ const ExcludedDomainSection = ({
           onClick={handleAdd}
           disabled={disabled}
         >
-          추가하기
+          {t("untrackedDomains.add")}
         </button>
       </div>
     </div>

--- a/apps/web/src/features/settings/ui/LanguageSection.tsx
+++ b/apps/web/src/features/settings/ui/LanguageSection.tsx
@@ -1,53 +1,26 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import {
-  DEFAULT_LANGUAGE,
-  type LanguageType,
-  SUPPORTED_LANGUAGES,
-} from "@recap/i18n";
+import { useState } from "react";
+import { type LanguageType, useLocale } from "@recap/i18n";
 import { cn } from "@recap/ui";
 
-import { LanguageSelect } from "@/entities/language/ui";
-
-const LOCALE_STORAGE_KEY = "re-today.locale";
-
-function parseStoredLocale(raw: string | null): LanguageType {
-  if (raw && SUPPORTED_LANGUAGES.includes(raw as LanguageType)) {
-    return raw as LanguageType;
-  }
-  return DEFAULT_LANGUAGE;
-}
+import { LanguageSelect, useLanguageStore } from "@/entities/language";
 
 type LanguageSectionProps = {
   disabled?: boolean;
 };
 
 const LanguageSection = ({ disabled = false }: LanguageSectionProps) => {
-  const [localize, setLocalize] = useState<LanguageType>(DEFAULT_LANGUAGE);
-  const [selectedLanguage, setSelectedLanguage] =
-    useState<LanguageType>(DEFAULT_LANGUAGE);
+  const { t } = useLocale("settings");
+  const localize = useLanguageStore((s) => s.localize);
+  const setLanguage = useLanguageStore((s) => s.setLanguage);
 
-  useEffect(() => {
-    const initial = parseStoredLocale(
-      window.localStorage.getItem(LOCALE_STORAGE_KEY),
-    );
-    setLocalize(initial);
-    setSelectedLanguage(initial);
-  }, []);
+  const [selectedLanguage, setSelectedLanguage] =
+    useState<LanguageType>(localize);
 
   const handleApply = () => {
     if (disabled || selectedLanguage === localize) return;
-    try {
-      window.localStorage.setItem(LOCALE_STORAGE_KEY, selectedLanguage);
-    } finally {
-      setLocalize(selectedLanguage);
-      window.dispatchEvent(
-        new CustomEvent<LanguageType>("localechange", {
-          detail: selectedLanguage,
-        }),
-      );
-    }
+    setLanguage(selectedLanguage);
   };
 
   return (
@@ -57,7 +30,9 @@ const LanguageSection = ({ disabled = false }: LanguageSectionProps) => {
         disabled && "pointer-events-none opacity-50",
       )}
     >
-      <h2 className="text-heading-rg text-gray-800">Language (언어변경)</h2>
+      <h2 className="text-heading-rg text-gray-800">
+        {t("languageChange.title")}
+      </h2>
 
       <div className="mt-6 flex flex-col items-stretch gap-6 md:flex-row md:items-center md:gap-4">
         <div className="w-full min-w-0 md:flex-1">
@@ -79,7 +54,7 @@ const LanguageSection = ({ disabled = false }: LanguageSectionProps) => {
           onClick={handleApply}
           disabled={disabled}
         >
-          적용하기
+          {t("languageChange.apply")}
         </button>
       </div>
     </div>

--- a/apps/web/src/features/settings/ui/LanguageSection.tsx
+++ b/apps/web/src/features/settings/ui/LanguageSection.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  DEFAULT_LANGUAGE,
+  type LanguageType,
+  SUPPORTED_LANGUAGES,
+} from "@recap/i18n";
+import { cn } from "@recap/ui";
+
+import { LanguageSelect } from "@/entities/language/ui";
+
+const LOCALE_STORAGE_KEY = "re-today.locale";
+
+function parseStoredLocale(raw: string | null): LanguageType {
+  if (raw && SUPPORTED_LANGUAGES.includes(raw as LanguageType)) {
+    return raw as LanguageType;
+  }
+  return DEFAULT_LANGUAGE;
+}
+
+type LanguageSectionProps = {
+  disabled?: boolean;
+};
+
+const LanguageSection = ({ disabled = false }: LanguageSectionProps) => {
+  const [localize, setLocalize] = useState<LanguageType>(DEFAULT_LANGUAGE);
+  const [selectedLanguage, setSelectedLanguage] =
+    useState<LanguageType>(DEFAULT_LANGUAGE);
+
+  useEffect(() => {
+    const initial = parseStoredLocale(
+      window.localStorage.getItem(LOCALE_STORAGE_KEY),
+    );
+    setLocalize(initial);
+    setSelectedLanguage(initial);
+  }, []);
+
+  const handleApply = () => {
+    if (disabled || selectedLanguage === localize) return;
+    try {
+      window.localStorage.setItem(LOCALE_STORAGE_KEY, selectedLanguage);
+    } finally {
+      setLocalize(selectedLanguage);
+      window.dispatchEvent(
+        new CustomEvent<LanguageType>("localechange", {
+          detail: selectedLanguage,
+        }),
+      );
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "rounded-[1.25rem] bg-white px-9 py-8 md:px-6 md:py-6 xl:px-9 xl:py-8",
+        disabled && "pointer-events-none opacity-50",
+      )}
+    >
+      <h2 className="text-heading-rg text-gray-800">Language (언어변경)</h2>
+
+      <div className="mt-6 flex flex-col items-stretch gap-6 md:flex-row md:items-center md:gap-4">
+        <div className="w-full min-w-0 md:flex-1">
+          <LanguageSelect
+            key={localize}
+            className="h-auto min-h-[52px] w-full rounded-xl border-gray-200 py-4"
+            defaultValue={localize}
+            onValueChange={setSelectedLanguage}
+            disabled={disabled}
+          />
+        </div>
+
+        <button
+          type="button"
+          className={cn(
+            "text-subtitle-1-md rounded-xl px-6 py-4 whitespace-nowrap text-gray-100",
+            selectedLanguage === localize ? "bg-gray-500" : "bg-gray-800",
+          )}
+          onClick={handleApply}
+          disabled={disabled}
+        >
+          적용하기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default LanguageSection;

--- a/apps/web/src/features/settings/ui/SimpleSelect.tsx
+++ b/apps/web/src/features/settings/ui/SimpleSelect.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { useLocale } from "@recap/i18n";
 import { cn } from "@recap/ui";
 
 type Option = {
@@ -30,6 +31,7 @@ export function SimpleSelect({
   contentClassName,
   maxMenuHeight = 300,
 }: SimpleSelectProps) {
+  const { t } = useLocale("common");
   const [open, setOpen] = React.useState(false);
 
   const rootRef = React.useRef<HTMLDivElement | null>(null);
@@ -86,7 +88,7 @@ export function SimpleSelect({
         )}
       >
         <span className={cn(!selected && "text-gray-400")}>
-          {selected ? selected.label : (placeholder ?? "선택")}
+          {selected ? selected.label : (placeholder ?? t("selectPlaceholder"))}
         </span>
 
         <svg

--- a/apps/web/src/features/settings/ui/UserProfile.tsx
+++ b/apps/web/src/features/settings/ui/UserProfile.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { catchAPIError } from "@recap/api";
+import { useLocale } from "@recap/i18n";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { authWithTokenAPIService } from "@/entities/auth/api";
@@ -14,6 +15,7 @@ import MailIcon from "@/shared/assets/icons/mail.svg";
 import DefaultImg from "@/shared/assets/img/recap-1.png";
 
 const UserProfile = ({ data }: { data: UserProfileType | undefined }) => {
+  const { t } = useLocale("settings");
   const { refreshAuth } = useAuth();
   const queryClient = useQueryClient();
 
@@ -39,7 +41,7 @@ const UserProfile = ({ data }: { data: UserProfileType | undefined }) => {
 
   return (
     <div className="rounded-[1.25rem] bg-white px-9 py-8">
-      <h2 className="text-heading-rg text-gray-800">내 계정</h2>
+      <h2 className="text-heading-rg text-gray-800">{t("account.title")}</h2>
 
       <div className="my-6 h-px w-full bg-gray-200" />
 
@@ -70,7 +72,7 @@ const UserProfile = ({ data }: { data: UserProfileType | undefined }) => {
           className="flex items-center gap-1 rounded-xl border border-solid border-gray-300 bg-white px-6 py-4"
           onClick={handleLogout}
         >
-          로그아웃
+          {t("account.logout")}
           <RightIcon />
         </button>
       </div>

--- a/apps/web/src/pages/ai-recap/ui/AiRecapUnloginPage.tsx
+++ b/apps/web/src/pages/ai-recap/ui/AiRecapUnloginPage.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import type { StaticImageData } from "next/image";
 import Image from "next/image";
+import { useLocale } from "@recap/i18n";
 
 import LoginBanner from "@/features/login/ui/LoginBanner";
 import EmptyRecapImg1 from "@/shared/assets/img/empty-reacp-1.png";
@@ -19,6 +22,8 @@ const PreviewImage = ({ src, alt }: { src: StaticImageData; alt: string }) => {
 };
 
 const AiRecapUnloginPage = () => {
+  const { t } = useLocale("ai-recap");
+
   return (
     <div className="flex flex-col gap-4 md:gap-5 xl:gap-7">
       <LoginBanner />
@@ -26,20 +31,26 @@ const AiRecapUnloginPage = () => {
       <div className="rounded-[1.25rem] bg-white px-5 py-5 md:px-6 md:py-6 xl:px-9 xl:py-8">
         <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div className="space-y-2">
-            <p className="text-heading-md text-blue-400">Today&apos;s Recap</p>
+            <p className="text-heading-md text-blue-400">
+              {t("screenTime.todayRecapTitle")}
+            </p>
             <h2 className="text-title-1 md:text-display-2 leading-tight text-gray-900">
-              매일밤 오늘의 인터넷 리캡을 배달해드려요
+              {t("screenTime.deliverRecapDailyNight")}
             </h2>
           </div>
 
           <div className="flex items-start justify-between gap-6 border-t border-solid border-gray-100 pt-4 md:justify-start md:gap-8 md:border-0 md:pt-0">
             <div className="min-w-26 space-y-1 md:w-26">
-              <p className="text-subtitle-2-rg text-gray-500">총 스크린타임</p>
+              <p className="text-subtitle-2-rg text-gray-500">
+                {t("screenTime.totalScreenTime")}
+              </p>
               <p className="text-heading-rg text-gray-900">-</p>
             </div>
             <div className="h-14 w-px bg-gray-200" />
             <div className="min-w-26 space-y-1 md:w-26">
-              <p className="text-subtitle-2-rg text-gray-500">측정시간</p>
+              <p className="text-subtitle-2-rg text-gray-500">
+                {t("screenTime.measurementTime")}
+              </p>
               <p className="text-heading-rg text-gray-900">-</p>
             </div>
           </div>
@@ -48,21 +59,21 @@ const AiRecapUnloginPage = () => {
 
       <div className="rounded-[1.25rem] bg-white px-5 py-5 md:px-6 md:py-6 xl:px-9 xl:py-8">
         <p className="text-heading-rg text-gray-800">
-          리캡은 이런 형태로 제공돼요
+          {t("preview.recapProvidedInThisFormat")}
         </p>
 
         <div className="mt-6 grid grid-cols-1 gap-4 md:mt-9 md:grid-cols-2 md:gap-9">
           <div>
-            <PreviewImage src={EmptyRecapImg1} alt="emptyRecapImg1" />
+            <PreviewImage src={EmptyRecapImg1} alt="" />
             <p className="text-body-1 md:text-headline-sb mt-3 text-gray-600 md:mt-4">
-              오늘 하루가 어떤 하루였는지 요약해드려요
+              {t("preview.summarizeYourDay")}
             </p>
           </div>
 
           <div>
-            <PreviewImage src={EmptyRecapImg2} alt="emptyRecapImg2" />
+            <PreviewImage src={EmptyRecapImg2} alt="" />
             <p className="text-body-1 md:text-headline-sb mt-3 text-gray-600 md:mt-4">
-              관심있었던 주제, 하루 타임라인을 확인해요
+              {t("preview.checkTopicsTimeline")}
             </p>
           </div>
         </div>

--- a/apps/web/src/pages/analysis/ui/AnalysisPage.tsx
+++ b/apps/web/src/pages/analysis/ui/AnalysisPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useLocale } from "@recap/i18n";
 
 import { AuthConsumer } from "@/entities/auth/ui";
 import CategoryAnalysis from "@/features/analysis/ui/CategoryAnalysis";
@@ -19,28 +20,34 @@ const AnalysisPage = ({ date }: { date: string }) => (
       if (!isReady) return <AnalysisLoadingPage />;
       if (!isLoggedIn) return <AnalysisUnloginPage />;
 
-      return (
-        <>
-          <div className="flex flex-col gap-4 md:gap-5 xl:gap-7">
-            <ScreenTime date={date} />
-            <CategoryAnalysis date={date} />
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-5 xl:gap-7">
-              <WorkPattern date={date} />
-              <TodayTimeThief date={date} />
-            </div>
-            <TopVisitedSites date={date} />
-          </div>
-          <Link
-            href="/settings"
-            className="text-subtitle-1-md mt-7 flex items-center justify-end gap-1 p-2 text-[#4378ff]"
-          >
-            추적금지 도메인 추가하기
-            <ArrowRightBlueIcon />
-          </Link>
-        </>
-      );
+      return <AnalysisLoggedInSection date={date} />;
     }}
   </AuthConsumer>
 );
+
+const AnalysisLoggedInSection = ({ date }: { date: string }) => {
+  const { t } = useLocale("analysis");
+
+  return (
+    <>
+      <div className="flex flex-col gap-4 md:gap-5 xl:gap-7">
+        <ScreenTime date={date} />
+        <CategoryAnalysis date={date} />
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-5 xl:gap-7">
+          <WorkPattern date={date} />
+          <TodayTimeThief date={date} />
+        </div>
+        <TopVisitedSites date={date} />
+      </div>
+      <Link
+        href="/settings"
+        className="text-subtitle-1-md mt-7 flex items-center justify-end gap-1 p-2 text-[#4378ff]"
+      >
+        {t("settings.addNonTrackingDomainLink")}
+        <ArrowRightBlueIcon />
+      </Link>
+    </>
+  );
+};
 
 export default AnalysisPage;

--- a/apps/web/src/pages/settings/ui/SettingsLoadingPage.tsx
+++ b/apps/web/src/pages/settings/ui/SettingsLoadingPage.tsx
@@ -1,6 +1,7 @@
 import { Skeleton } from "@recap/ui";
 
 import ExcludedDomainSection from "@/features/settings/ui/ExcludedDomainSection";
+import LanguageSection from "@/features/settings/ui/LanguageSection";
 
 const SettingsLoadingPage = () => {
   return (
@@ -14,6 +15,7 @@ const SettingsLoadingPage = () => {
         </div>
       </div>
 
+      <LanguageSection />
       <ExcludedDomainSection domains={[]} disabled />
     </>
   );

--- a/apps/web/src/pages/settings/ui/SettingsPage.tsx
+++ b/apps/web/src/pages/settings/ui/SettingsPage.tsx
@@ -3,6 +3,7 @@
 import { AuthConsumer } from "@/entities/auth/ui";
 import { useUserProfile } from "@/features/settings/api/use-get-user-profile";
 import ExcludedDomainSection from "@/features/settings/ui/ExcludedDomainSection";
+import LanguageSection from "@/features/settings/ui/LanguageSection";
 import UserProfile from "@/features/settings/ui/UserProfile";
 
 import SettingsLoadingPage from "./SettingsLoadingPage";
@@ -27,6 +28,7 @@ const LoggedInSettings = () => {
   return (
     <>
       <UserProfile data={profile} />
+      <LanguageSection />
       <ExcludedDomainSection domains={profile.excludedDomains} />
     </>
   );

--- a/apps/web/src/pages/settings/ui/SettingsUnloginPage.tsx
+++ b/apps/web/src/pages/settings/ui/SettingsUnloginPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLocale } from "@recap/i18n";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useAuth } from "@/entities/auth/ui";
@@ -9,6 +10,7 @@ import ExcludedDomainSection from "@/features/settings/ui/ExcludedDomainSection"
 import LanguageSection from "@/features/settings/ui/LanguageSection";
 
 const SettingsUnloginPage = () => {
+  const { t } = useLocale("settings");
   const { refreshAuth } = useAuth();
   const queryClient = useQueryClient();
 
@@ -23,7 +25,7 @@ const SettingsUnloginPage = () => {
     <>
       <div className="rounded-[1.25rem] bg-white px-5 py-5 md:px-6 md:py-6 xl:px-9 xl:py-8">
         <p className="text-body-1 text-gray-800">
-          로그인하고 내 하루 기록을 확인해 보세요
+          {t("account.dailyRecordsPrompt")}
         </p>
 
         <div className="my-6 h-px w-full bg-gray-200" />
@@ -31,7 +33,9 @@ const SettingsUnloginPage = () => {
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center gap-3">
             <div className="size-14 rounded-full bg-gray-200" />
-            <p className="text-headline-sb text-gray-800">로그인</p>
+            <p className="text-headline-sb text-gray-800">
+              {t("account.login")}
+            </p>
           </div>
 
           <LoginButton onLoginSuccess={handleLoginSuccess} />

--- a/apps/web/src/pages/settings/ui/SettingsUnloginPage.tsx
+++ b/apps/web/src/pages/settings/ui/SettingsUnloginPage.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/entities/auth/ui";
 import LoginButton from "@/features/login/ui/LoginButton";
 import { USER_PROFILE_QUERY_KEY } from "@/features/settings/api/use-get-user-profile";
 import ExcludedDomainSection from "@/features/settings/ui/ExcludedDomainSection";
+import LanguageSection from "@/features/settings/ui/LanguageSection";
 
 const SettingsUnloginPage = () => {
   const { refreshAuth } = useAuth();
@@ -37,6 +38,7 @@ const SettingsUnloginPage = () => {
         </div>
       </div>
 
+      <LanguageSection />
       <ExcludedDomainSection domains={[]} disabled />
     </>
   );

--- a/apps/web/src/shared/config/navigation.const.ts
+++ b/apps/web/src/shared/config/navigation.const.ts
@@ -7,23 +7,25 @@ export const NAVIGATION_TAB = {
 export type NavigationTabValue =
   (typeof NAVIGATION_TAB)[keyof typeof NAVIGATION_TAB];
 
+export type LandingNavigationLabelKey = "analysis" | "aiRecap" | "settings";
+
 export const GNB_TABS: {
-  label: string;
+  labelKey: LandingNavigationLabelKey;
   value: NavigationTabValue;
   path: string;
 }[] = [
   {
-    label: "분석",
+    labelKey: "analysis",
     value: "analysis",
     path: "/analysis",
   },
   {
-    label: "AI 리캡",
+    labelKey: "aiRecap",
     value: "ai-recap",
     path: "/ai-recap",
   },
   {
-    label: "설정",
+    labelKey: "settings",
     value: "settings",
     path: "/settings",
   },

--- a/apps/web/src/shared/lib/date/format-date.ts
+++ b/apps/web/src/shared/lib/date/format-date.ts
@@ -1,0 +1,27 @@
+import { dayjs, formatDuration } from "@recap/utils";
+
+/**
+ * 초 단위 길이를 분으로 환산한 뒤 반올림합니다.
+ * 비유효·비양수 값은 0으로 처리합니다.
+ */
+export function secondsToMinute(seconds: number): number {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return 0;
+  }
+  const minutes = dayjs.duration(seconds, "seconds").asMinutes();
+  return Math.round(minutes);
+}
+
+/**
+ * 초 단위 길이를 가장 가까운 정수 분으로 반올림한 뒤 {@link formatDuration}과 동일한 규칙으로 문자열로 표시합니다.
+ */
+export function formatSecondsToMinutes(
+  seconds: number,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string {
+  if (seconds <= 0 || Number.isNaN(seconds)) {
+    return formatDuration(0, t);
+  }
+  const totalMinutes = Math.round(seconds / 60);
+  return formatDuration(totalMinutes * 60, t);
+}

--- a/apps/web/src/widgets/layout/ui/TabNavigation.tsx
+++ b/apps/web/src/widgets/layout/ui/TabNavigation.tsx
@@ -1,18 +1,21 @@
 "use client";
 
+import { useLocale } from "@recap/i18n";
+
 import { GNB_TABS } from "@/shared/config";
 import { GnbTabs, GnbTabsList, GnbTabsTrigger } from "@/shared/ui";
 import { useGnbNavigation } from "@/widgets/layout/model/use-gnb-navigation";
 
 const TabNavigation = () => {
+  const { t } = useLocale("landing");
   const { currentTab, onTabChange } = useGnbNavigation();
 
   return (
     <GnbTabs value={currentTab} onValueChange={onTabChange} className="w-fit">
       <GnbTabsList>
-        {GNB_TABS.map(({ label, value }) => (
+        {GNB_TABS.map(({ labelKey, value }) => (
           <GnbTabsTrigger key={value} value={value}>
-            {label}
+            {t(`navigation.${labelKey}`)}
           </GnbTabsTrigger>
         ))}
       </GnbTabsList>

--- a/packages/i18n/next-i18next.config.cjs
+++ b/packages/i18n/next-i18next.config.cjs
@@ -1,0 +1,35 @@
+"use strict";
+
+/**
+ * next-i18next–style shared config (aligned with cal.diy packages/i18n).
+ *
+ * Do not set `i18n: this.i18n` inside Next.js `next.config` when using the
+ * App Router — Next 16 treats it as the Pages Router locale prefix and will
+ * break prerender (`/ko/...` routes). Keep locale routing in middleware /
+ * `[locale]` segments if needed; this file remains the single source for
+ * locale lists + paths for `next-i18next` helpers and `@recap/i18n/server`.
+ */
+
+const path = require("node:path");
+
+const defaultLocale = "ko";
+const locales = ["ko", "en", "ja"];
+
+/**
+ * Shared Next.js / next-i18next–style config (see cal.diy packages/i18n).
+ * Use `i18n` in `next.config` for routing defaults; use `localePath` with
+ * next-i18next helpers or `@recap/i18n/server` for App Router RSC.
+ */
+module.exports = {
+  i18n: {
+    defaultLocale,
+    locales,
+  },
+  fallbackLng: {
+    default: [defaultLocale],
+  },
+  reloadOnPrerender: process.env.NODE_ENV !== "production",
+  localePath: path.resolve(__dirname, "src/locales"),
+  defaultNS: "landing",
+  ns: ["ai-recap", "analysis", "common", "landing", "settings"],
+};

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -6,7 +6,9 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
-    "./locales/*": "./locales/*"
+    "./locales/*": "./src/locales/*",
+    "./next-i18next.config": "./next-i18next.config.cjs",
+    "./server": "./src/server.ts"
   },
   "dependencies": {
     "i18next": "^26.0.6",

--- a/packages/i18n/src/I18nProvider.tsx
+++ b/packages/i18n/src/I18nProvider.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { type ReactNode, useEffect } from "react";
 import { I18nextProvider } from "react-i18next";
 import type { i18n as I18nInstance } from "i18next";

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -11,6 +11,7 @@ export {
 export { createI18n, type CreateI18nOptions, i18n } from "./i18n";
 export { I18nProvider, type I18nProviderProps } from "./I18nProvider";
 export { useLocale, type UseLocaleReturn } from "./use-locale";
+export type { TFunction } from "i18next";
 export type {
   TransProps,
   UseTranslationOptions,

--- a/packages/i18n/src/locales/en/ai-recap.json
+++ b/packages/i18n/src/locales/en/ai-recap.json
@@ -25,8 +25,12 @@
     "measurementTimeLabel": "Measurement Time",
     "dailySummaryLabel": "Daily Summary",
     "aiTimelineTitle": "AI Timeline",
+    "aiTimelineSubtitle": "Today's flow summarized by Retoday",
+    "timelineEmpty": "No timeline data yet",
+    "topicsEmpty": "No topic data yet",
+    "summarySectionsEmpty": "No summary content yet",
     "lookingBackTitle": "Looking Back at Today",
-    "mostViewedTopicsTitle": "Most Viewed Topics",
+    "mostViewedTopicsTitle": "Most browsed topics",
     "todayTopicsTitle": "Today's topics"
   }
 }

--- a/packages/i18n/src/locales/en/analysis.json
+++ b/packages/i18n/src/locales/en/analysis.json
@@ -6,10 +6,23 @@
     "buttonWeekly": "Weekly",
     "weeklyAverageTitle": "This week's average screen time",
     "perDayAverage": "{{duration}} per day",
-    "dailyTimeSlotSubLabel": "Today {{start}}:00 - {{end}}:00"
+    "dailyTimeSlotSubLabel": "Today {{start}}:00 - {{end}}:00",
+    "emptyWeeklyChartAlt": "No accumulated activity for this week yet",
+    "emptyDailyChartAlt": "No accumulated activity for this day",
+    "weekdayShort": {
+      "sun": "Sun",
+      "mon": "Mon",
+      "tue": "Tue",
+      "wed": "Wed",
+      "thu": "Thu",
+      "fri": "Fri",
+      "sat": "Sat"
+    }
   },
   "category": {
     "title": "Category Analysis",
+    "filterAll": "All",
+    "emptyState": "No analysis data yet",
     "shoppingFocusSummary": "You spent <time>{{time_spent}}</time> immersed in <category>{{category}}</category>",
     "moreInDashboard": "See more details in the dashboard",
     "bubbleRankAria": "Rank {{rank}}: {{label}}",
@@ -28,6 +41,10 @@
   },
   "workPattern": {
     "title": "My Work Pattern",
+    "labelDawn": "Night owl worker",
+    "labelMorning": "Early bird worker",
+    "labelDaytime": "Daytime worker",
+    "labelEvening": "Evening worker",
     "earlyBird": "Early Bird Worker",
     "earlyBirdDiligent": "Diligent Early Bird Worker",
     "daytimeDiligent": "Diligent Daytime Worker",
@@ -35,11 +52,13 @@
   },
   "timeThief": {
     "title": "Today's Time Thief",
+    "totalLabel": "Total {{duration}}",
     "totalDurationExample": "Total {duration}",
     "imageAlt": "Time thief"
   },
   "frequentSites": {
     "title": "Frequently Visited Sites",
+    "emptyState": "No visited sites recorded yet",
     "visitCountDurationExample": "{count} visits {duration}"
   },
   "settings": {

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -6,5 +6,8 @@
     "minute_other": "{{count}} minutes",
     "second_one": "{{count}} second",
     "second_other": "{{count}} seconds"
-  }
+  },
+  "selectPlaceholder": "Select",
+  "meridiemAm": "am",
+  "meridiemPm": "pm"
 }

--- a/packages/i18n/src/locales/en/setting.json
+++ b/packages/i18n/src/locales/en/setting.json
@@ -4,12 +4,16 @@
     "name": "Account Name",
     "login": "Sign In",
     "logout": "Log Out",
-    "dailyRecordsPrompt": "Log in and check my daily records"
+    "dailyRecordsPrompt": "Log in and check my daily records",
+    "sampleDataCaption": "What you see now is sample data"
   },
   "languageChange": {
     "title": "언어 변경 (Language)",
     "selectedLanguage": "Selected Language",
     "apply": "Apply"
+  },
+  "language": {
+    "selectPlaceholder": "Selected language"
   },
   "recapFrequency": {
     "title": "Recap Frequency Settings",

--- a/packages/i18n/src/locales/ja/ai-recap.json
+++ b/packages/i18n/src/locales/ja/ai-recap.json
@@ -25,6 +25,10 @@
     "measurementTimeLabel": "測定時間",
     "dailySummaryLabel": "一日の要約",
     "aiTimelineTitle": "AIタイムライン",
+    "aiTimelineSubtitle": "Retodayがまとめた今日一日の流れ",
+    "timelineEmpty": "タイムラインデータがありません",
+    "topicsEmpty": "テーマデータがありません",
+    "summarySectionsEmpty": "要約された内容がありません",
     "lookingBackTitle": "今日一日を振り返る",
     "mostViewedTopicsTitle": "よく閲覧したテーマ",
     "todayTopicsTitle": "今日のトピック"

--- a/packages/i18n/src/locales/ja/analysis.json
+++ b/packages/i18n/src/locales/ja/analysis.json
@@ -6,10 +6,23 @@
     "buttonWeekly": "週ごと",
     "weeklyAverageTitle": "今週の平均スクリーンタイム",
     "perDayAverage": "1日あたり {{duration}}",
-    "dailyTimeSlotSubLabel": "今日 {{start}}:00 - {{end}}:00"
+    "dailyTimeSlotSubLabel": "今日 {{start}}:00 - {{end}}:00",
+    "emptyWeeklyChartAlt": "今週はまだ累積された活動がありません",
+    "emptyDailyChartAlt": "この日は累積された活動がありません",
+    "weekdayShort": {
+      "sun": "日",
+      "mon": "月",
+      "tue": "火",
+      "wed": "水",
+      "thu": "木",
+      "fri": "金",
+      "sat": "土"
+    }
   },
   "category": {
     "title": "カテゴリー別分析",
+    "filterAll": "すべて",
+    "emptyState": "分析データがありません",
     "shoppingFocusSummary": "<category>{{category}}</category>に<time>{{time_spent}}</time>没頭しました",
     "moreInDashboard": "詳しくはダッシュボードでご確認ください",
     "bubbleRankAria": "{{rank}}位: {{label}}",
@@ -28,6 +41,10 @@
   },
   "workPattern": {
     "title": "私の作業パターン",
+    "labelDawn": "夜型ワーカー",
+    "labelMorning": "朝型ワーカー",
+    "labelDaytime": "日中型ワーカー",
+    "labelEvening": "夕方型ワーカー",
     "earlyBird": "朝型ワーカー",
     "earlyBirdDiligent": "勤勉な朝型ワーカー",
     "daytimeDiligent": "誠実な昼型ワーカー",
@@ -35,11 +52,13 @@
   },
   "timeThief": {
     "title": "今日の時間泥棒",
+    "totalLabel": "合計 {{duration}}",
     "totalDurationExample": "合計 {duration}",
     "imageAlt": "時間泥棒"
   },
   "frequentSites": {
     "title": "よく訪れたサイト",
+    "emptyState": "まだ訪れたサイトの記録がありません",
     "visitCountDurationExample": "{count}回 {duration}"
   },
   "settings": {

--- a/packages/i18n/src/locales/ja/common.json
+++ b/packages/i18n/src/locales/ja/common.json
@@ -3,5 +3,8 @@
     "hour_other": "{{count}}時間",
     "minute_other": "{{count}}分",
     "second_other": "{{count}}秒"
-  }
+  },
+  "selectPlaceholder": "選択",
+  "meridiemAm": "am",
+  "meridiemPm": "pm"
 }

--- a/packages/i18n/src/locales/ja/setting.json
+++ b/packages/i18n/src/locales/ja/setting.json
@@ -4,12 +4,16 @@
     "name": "アカウント名",
     "login": "ログイン",
     "logout": "ログアウト",
-    "dailyRecordsPrompt": "ログインして、今日の記録を確認してみてください"
+    "dailyRecordsPrompt": "ログインして、今日の記録を確認してみてください",
+    "sampleDataCaption": "現在表示されているのはサンプルデータです"
   },
   "languageChange": {
     "title": "言語変更（Language）",
     "selectedLanguage": "Selected Language",
     "apply": "適用する"
+  },
+  "language": {
+    "selectPlaceholder": "選択中の言語"
   },
   "recapFrequency": {
     "title": "リキャップ頻度設定",

--- a/packages/i18n/src/locales/ko/ai-recap.json
+++ b/packages/i18n/src/locales/ko/ai-recap.json
@@ -25,8 +25,12 @@
     "measurementTimeLabel": "측정시간",
     "dailySummaryLabel": "하루 요약",
     "aiTimelineTitle": "AI 타임라인",
+    "aiTimelineSubtitle": "Retoday가 요약한 오늘 하루의 흐름",
+    "timelineEmpty": "타임라인 데이터가 없어요",
+    "topicsEmpty": "주제 데이터가 없어요",
+    "summarySectionsEmpty": "요약된 내용이 없어요",
     "lookingBackTitle": "오늘 하루 돌아보기",
-    "mostViewedTopicsTitle": "많이 돌려본 주제",
+    "mostViewedTopicsTitle": "많이 둘러본 주제",
     "todayTopicsTitle": "오늘의 주제"
   }
 }

--- a/packages/i18n/src/locales/ko/analysis.json
+++ b/packages/i18n/src/locales/ko/analysis.json
@@ -6,10 +6,23 @@
     "buttonWeekly": "주간",
     "weeklyAverageTitle": "이번주 평균 스크린타임",
     "perDayAverage": "하루 {{duration}}",
-    "dailyTimeSlotSubLabel": "오늘 {{start}}:00 - {{end}}:00"
+    "dailyTimeSlotSubLabel": "오늘 {{start}}:00 - {{end}}:00",
+    "emptyWeeklyChartAlt": "이번 주간에는 아직 누적된 활동이 보이지 않아요",
+    "emptyDailyChartAlt": "이 날에는 누적된 활동이 없어요",
+    "weekdayShort": {
+      "sun": "일",
+      "mon": "월",
+      "tue": "화",
+      "wed": "수",
+      "thu": "목",
+      "fri": "금",
+      "sat": "토"
+    }
   },
   "category": {
     "title": "카테고리별 분석",
+    "filterAll": "전체",
+    "emptyState": "분석 데이터가 없어요",
     "shoppingFocusSummary": "<category>{{category}}</category>에 <time>{{time_spent}}</time> 몰두했어요",
     "moreInDashboard": "더 자세한 내역은 대시보드에서 확인해주세요",
     "bubbleRankAria": "{{rank}}등: {{label}}",
@@ -28,6 +41,10 @@
   },
   "workPattern": {
     "title": "내 작업 패턴",
+    "labelDawn": "야행성 작업자",
+    "labelMorning": "얼리버드 작업자",
+    "labelDaytime": "주간 작업자",
+    "labelEvening": "저녁형 작업자",
     "earlyBird": "얼리버드 작업자",
     "earlyBirdDiligent": "부지런한 얼리버드 작업러",
     "daytimeDiligent": "성실한 데이타임 작업러",
@@ -35,11 +52,13 @@
   },
   "timeThief": {
     "title": "오늘의 시간 도둑",
+    "totalLabel": "총 {{duration}}",
     "totalDurationExample": "총 {duration}",
     "imageAlt": "시간 도둑"
   },
   "frequentSites": {
     "title": "자주 방문한 사이트",
+    "emptyState": "아직 기록된 방문 사이트가 없어요",
     "visitCountDurationExample": "{count}회 {duration}"
   },
   "settings": {

--- a/packages/i18n/src/locales/ko/common.json
+++ b/packages/i18n/src/locales/ko/common.json
@@ -3,5 +3,8 @@
     "hour_other": "{{count}}시간",
     "minute_other": "{{count}}분",
     "second_other": "{{count}}초"
-  }
+  },
+  "selectPlaceholder": "선택",
+  "meridiemAm": "am",
+  "meridiemPm": "pm"
 }

--- a/packages/i18n/src/locales/ko/setting.json
+++ b/packages/i18n/src/locales/ko/setting.json
@@ -4,12 +4,16 @@
     "name": "계정이름",
     "login": "로그인",
     "logout": "로그아웃",
-    "dailyRecordsPrompt": "로그인하고 내 하루 기록을 확인해 보세요"
+    "dailyRecordsPrompt": "로그인하고 내 하루 기록을 확인해 보세요",
+    "sampleDataCaption": "지금 보이는 화면은 샘플데이터에요"
   },
   "languageChange": {
     "title": "언어 변경 (Language)",
     "selectedLanguage": "Selected Language",
     "apply": "적용하기"
+  },
+  "language": {
+    "selectPlaceholder": "선택된 언어"
   },
   "recapFrequency": {
     "title": "리캡 주기 설정",

--- a/packages/i18n/src/server.ts
+++ b/packages/i18n/src/server.ts
@@ -1,0 +1,95 @@
+import type { TFunction } from "i18next";
+import { createInstance } from "i18next";
+
+import {
+  DEFAULT_LANGUAGE,
+  type LanguageType,
+  type Namespace,
+  NAMESPACES,
+  SUPPORTED_LANGUAGES,
+} from "./constants";
+
+type LocaleJson = Record<string, unknown>;
+
+function namespaceToFilename(ns: string): string {
+  if (ns === NAMESPACES.SETTINGS) return "setting";
+  return ns;
+}
+
+function isSupportedLocale(locale: string): locale is LanguageType {
+  return SUPPORTED_LANGUAGES.includes(locale as LanguageType);
+}
+
+export function mergeWithEnglishFallback(
+  english: LocaleJson,
+  locale: LocaleJson,
+): LocaleJson {
+  return { ...english, ...locale };
+}
+
+const translationCache = new Map<string, LocaleJson>();
+const tCache = new Map<string, TFunction>();
+
+const ALL_NS = Object.values(NAMESPACES) as string[];
+
+/**
+ * Load merged translations (English fallback + locale) for a namespace.
+ * Server-only: uses dynamic imports under `src/locales`.
+ */
+export async function loadTranslations(
+  _locale: string,
+  _ns: string,
+): Promise<LocaleJson> {
+  const locale = isSupportedLocale(_locale) ? _locale : DEFAULT_LANGUAGE;
+  const ns = ALL_NS.includes(_ns) ? _ns : NAMESPACES.COMMON;
+  const cacheKey = `${locale}-${ns}`;
+
+  const hit = translationCache.get(cacheKey);
+  if (hit) return hit;
+
+  const file = namespaceToFilename(ns);
+
+  const { default: englishRaw } = await import(`./locales/en/${file}.json`);
+  const english = englishRaw as LocaleJson;
+
+  if (locale === "en") {
+    translationCache.set(cacheKey, english);
+    return english;
+  }
+
+  const { default: localeRaw } = await import(
+    `./locales/${locale}/${file}.json`
+  );
+  const merged = mergeWithEnglishFallback(english, localeRaw as LocaleJson);
+  translationCache.set(cacheKey, merged);
+  return merged;
+}
+
+/**
+ * Cached `getFixedT` for server components / Route Handlers (cal.diy-style).
+ */
+export async function getTranslation(
+  locale: string,
+  ns: Namespace,
+): Promise<TFunction> {
+  const safeLocale = isSupportedLocale(locale) ? locale : DEFAULT_LANGUAGE;
+  const cacheKey = `${safeLocale}-${ns}`;
+  const cached = tCache.get(cacheKey);
+  if (cached) return cached;
+
+  const resources = await loadTranslations(safeLocale, ns);
+  const i18n = createInstance();
+  await i18n.init({
+    lng: safeLocale,
+    resources: {
+      [safeLocale]: {
+        [ns]: resources,
+      },
+    },
+    fallbackLng: DEFAULT_LANGUAGE,
+  });
+
+  const t = i18n.getFixedT(safeLocale, ns);
+  tCache.set(cacheKey, t);
+  return t;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@recap/i18n':
+        specifier: workspace:*
+        version: link:../../packages/i18n
       '@tanstack/react-query':
         specifier: ^5.0.0
         version: 5.90.20(react@19.2.0)
@@ -205,6 +208,9 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+      zustand:
+        specifier: ^5.0.12
+        version: 5.0.12(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
     devDependencies:
       '@recap/api':
         specifier: workspace:*
@@ -215,9 +221,6 @@ importers:
       '@recap/hooks':
         specifier: workspace:*
         version: link:../../packages/hooks
-      '@recap/i18n':
-        specifier: workspace:*
-        version: link:../../packages/i18n
       '@recap/react-query':
         specifier: workspace:*
         version: link:../../packages/react-query-config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,12 @@ importers:
       '@recap/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
+      '@recap/hooks':
+        specifier: workspace:*
+        version: link:../../packages/hooks
+      '@recap/i18n':
+        specifier: workspace:*
+        version: link:../../packages/i18n
       '@recap/react-query':
         specifier: workspace:*
         version: link:../../packages/react-query-config


### PR DESCRIPTION
## 작업 내용

- **`@recap/i18n`**
  - Next.js용 `next-i18next` 설정(`next-i18next.config.cjs`) 및 서버 측 번들/리소스 로딩(`server.ts`) 정리
  - `I18nProvider` 보강 및 웹에서 사용할 수 있도록 패키지 export 정리
- **웹 앱 라우트·프로바이더**
  - 루트 레이아웃에 `LanguageProvider` 연동, 언어 상태와 i18n `lng` 동기화
  - `entities/language`에 Zustand 기반 언어 스토어(클라이언트 persist) 및 `LanguageSelect` UI
- **설정**
  - 설정 화면에 언어 선택·적용 UI(`LanguageSection`) 추가, 익스텐션과 유사한 적용 플로우
- **화면별 번역 적용**
  - AI 리캡·분석·로그인·설정·미로그인 랜딩 등에서 `useLocale` 기반 문구 치환
  - 탭/내비게이션 라벨 등 공통 영역 로케일 반영(`navigation` 등)
- **날짜·시간 표시**
  - 리캡/분석 등에서 기간·스크린타임 표기를 로케일에 맞게 다루기 위한 포맷·매핑 보조(`format-date`, `screen-time-bar-data` 등)
- **로케일 리소스**
  - `ko` / `en` / `ja`의 `common`, `ai-recap`, `analysis`, `setting` 등 JSON 보강·정리


## 작업 목적

- 웹에서도 익스텐션과 동일한 **언어 선택 경험**을 제공하고, **한·영·일** UI 문구를 일관되게 표시한다.
- 공용 `@recap/i18n` 패키지와 Next.js 앱 라우터 구조에 맞게 **서버/클라이언트 번역 로딩**을 맞춘다.
- 설정에서 언어를 바꾼 뒤 **저장·재방문 시에도** 선택 언어가 유지되도록 한다.

### 스크린샷 (선택)

- 설정 > 언어 섹션(드롭다운 + 적용 버튼)
- AI 리캡 / 분석 탭 전환 시 로케일별 라벨·본문
- (선택) `ko` / `en` / `ja` 각각 한 장씩
