### PR TITLE
feat: 디자인 시스템 기반 UI 컴포넌트 추가 

### DIFF
--- a/packages/tailwind-config/preset.js
+++ b/packages/tailwind-config/preset.js
@@ -1,5 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 const preset = {
+  safelist: [
+    {
+      pattern: /^(sm:|md:|lg:|xl:)?grid-cols-(?:1[0-2]|[1-9])$/,
+    },
+  ],
   theme: {
     extend: {
       fontFamily: {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.12",
+    "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-select": "^2.2.6",

--- a/packages/ui/src/avatar.tsx
+++ b/packages/ui/src/avatar.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+
+import { cn } from "./utils/cn";
+
+const Avatar = React.forwardRef<
+  React.ComponentRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex size-14 shrink-0 overflow-hidden rounded-full",
+      className,
+    )}
+    {...props}
+  />
+));
+Avatar.displayName = AvatarPrimitive.Root.displayName ?? "Avatar";
+
+const AvatarImage = React.forwardRef<
+  React.ComponentRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square size-full object-cover", className)}
+    {...props}
+  />
+));
+AvatarImage.displayName = AvatarPrimitive.Image.displayName ?? "AvatarImage";
+
+const AvatarFallback = React.forwardRef<
+  React.ComponentRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex size-full items-center justify-center rounded-full bg-gray-200",
+      className,
+    )}
+    {...props}
+  />
+));
+AvatarFallback.displayName =
+  AvatarPrimitive.Fallback.displayName ?? "AvatarFallback";
+
+export { Avatar, AvatarFallback, AvatarImage };

--- a/packages/ui/src/card.tsx
+++ b/packages/ui/src/card.tsx
@@ -1,0 +1,126 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "./utils/cn";
+
+const cardVariants = cva(
+  "flex min-w-0 flex-col rounded-[1.25rem] bg-white text-gray-900",
+  {
+    variants: {
+      variant: {
+        default: "shadow-none",
+        bordered: "ring-1 ring-inset ring-gray-100 shadow-none",
+        elevated:
+          "border border-transparent shadow-[0_1px_3px_rgb(15_23_42/0.06)] shadow-gray-900/10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export type CardProps = React.ComponentPropsWithoutRef<"div"> &
+  VariantProps<typeof cardVariants> & {
+    asChild?: boolean;
+  };
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, variant, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "div";
+    return (
+      <Comp
+        ref={ref}
+        data-slot="card"
+        className={cn(cardVariants({ variant }), className)}
+        {...props}
+      />
+    );
+  },
+);
+Card.displayName = "Card";
+
+export type CardHeaderProps = React.ComponentPropsWithoutRef<"div">;
+
+const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="card-header"
+      className={cn("flex shrink-0 flex-col gap-1.5 px-6 pt-6", className)}
+      {...props}
+    />
+  ),
+);
+CardHeader.displayName = "CardHeader";
+
+export type CardTitleProps = React.ComponentPropsWithoutRef<"div">;
+
+const CardTitle = React.forwardRef<HTMLDivElement, CardTitleProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="card-title"
+      className={cn("break-words text-heading-rg text-gray-800", className)}
+      {...props}
+    />
+  ),
+);
+CardTitle.displayName = "CardTitle";
+
+export type CardDescriptionProps = React.ComponentPropsWithoutRef<"p">;
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  CardDescriptionProps
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    data-slot="card-description"
+    className={cn("text-body-2 m-0 min-w-0 text-gray-600", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+export type CardContentProps = React.ComponentPropsWithoutRef<"div">;
+
+const CardContent = React.forwardRef<HTMLDivElement, CardContentProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="card-content"
+      className={cn("min-w-0 flex-1 px-6 pb-6 pt-0", className)}
+      {...props}
+    />
+  ),
+);
+CardContent.displayName = "CardContent";
+
+export type CardFooterProps = React.ComponentPropsWithoutRef<"div">;
+
+const CardFooter = React.forwardRef<HTMLDivElement, CardFooterProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="card-footer"
+      className={cn(
+        "flex shrink-0 flex-wrap items-center gap-3 px-6 pb-6 pt-0",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+CardFooter.displayName = "CardFooter";
+
+export {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  cardVariants,
+};

--- a/packages/ui/src/divider.tsx
+++ b/packages/ui/src/divider.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+import { cn } from "./utils/cn";
+
+export interface DividerProps extends React.HTMLAttributes<HTMLDivElement> {
+  orientation?: "horizontal" | "vertical";
+}
+
+const Divider = React.forwardRef<HTMLDivElement, DividerProps>(
+  (
+    { className, orientation = "horizontal", role = "separator", ...props },
+    ref,
+  ) => (
+    <div
+      ref={ref}
+      role={role}
+      aria-orientation={orientation === "vertical" ? "vertical" : undefined}
+      data-orientation={orientation}
+      className={cn(
+        "shrink-0 bg-gray-200",
+        orientation === "horizontal"
+          ? "h-px min-w-0 w-full"
+          : "h-14 w-px self-center",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Divider.displayName = "Divider";
+
+export { Divider };

--- a/packages/ui/src/flex.tsx
+++ b/packages/ui/src/flex.tsx
@@ -1,0 +1,101 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "./utils/cn";
+import {
+  GAP_SEMANTIC,
+  GAP_X_SEMANTIC,
+  GAP_Y_SEMANTIC,
+  type GapSize,
+} from "./utils/gap-scale";
+
+const flexVariants = cva("flex", {
+  variants: {
+    direction: {
+      row: "flex-row",
+      column: "flex-col",
+      "row-reverse": "flex-row-reverse",
+      "column-reverse": "flex-col-reverse",
+    },
+    wrap: {
+      wrap: "flex-wrap",
+      nowrap: "flex-nowrap",
+      "wrap-reverse": "flex-wrap-reverse",
+    },
+    align: {
+      stretch: "items-stretch",
+      center: "items-center",
+      "flex-start": "items-start",
+      "flex-end": "items-end",
+    },
+    justify: {
+      "flex-start": "justify-start",
+      center: "justify-center",
+      "flex-end": "justify-end",
+      "space-between": "justify-between",
+      "space-around": "justify-around",
+    },
+    gap: GAP_SEMANTIC,
+    columnGap: GAP_X_SEMANTIC,
+    rowGap: GAP_Y_SEMANTIC,
+  },
+  defaultVariants: {
+    direction: "row",
+    wrap: "nowrap",
+    align: "stretch",
+    justify: "flex-start",
+    gap: "none",
+    columnGap: "none",
+    rowGap: "none",
+  },
+});
+
+export interface FlexProps extends React.HTMLAttributes<HTMLDivElement> {
+  align?: VariantProps<typeof flexVariants>["align"];
+  columnGap?: GapSize;
+  direction?: VariantProps<typeof flexVariants>["direction"];
+  gap?: GapSize;
+  justify?: VariantProps<typeof flexVariants>["justify"];
+  rowGap?: GapSize;
+  size?: GapSize;
+  wrap?: VariantProps<typeof flexVariants>["wrap"];
+}
+
+const Flex = React.forwardRef<HTMLDivElement, FlexProps>(
+  (
+    {
+      className,
+      align,
+      columnGap,
+      direction,
+      gap,
+      justify,
+      rowGap,
+      wrap,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          flexVariants({
+            direction,
+            wrap,
+            align,
+            justify,
+            gap: gap ?? "none",
+            columnGap: columnGap ?? "none",
+            rowGap: rowGap ?? "none",
+          }),
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Flex.displayName = "Flex";
+
+export { Flex, flexVariants };

--- a/packages/ui/src/grid.tsx
+++ b/packages/ui/src/grid.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { cva } from "class-variance-authority";
+
+import { cn } from "./utils/cn";
+import {
+  GAP_SEMANTIC,
+  GAP_X_SEMANTIC,
+  GAP_Y_SEMANTIC,
+  type GapSize,
+} from "./utils/gap-scale";
+import {
+  type GridColumnCount,
+  type GridTemplateColsBreakpoints,
+  gridTemplateColsClass,
+} from "./utils/grid-template-cols";
+
+const gridVariants = cva("grid", {
+  variants: {
+    gap: GAP_SEMANTIC,
+    columnGap: GAP_X_SEMANTIC,
+    rowGap: GAP_Y_SEMANTIC,
+  },
+  defaultVariants: {
+    gap: "none",
+    columnGap: "none",
+    rowGap: "none",
+  },
+});
+
+export type GridCols = GridColumnCount | GridTemplateColsBreakpoints;
+
+export interface GridProps extends React.HTMLAttributes<HTMLDivElement> {
+  cols?: GridCols;
+  columnGap?: GapSize;
+  gap?: GapSize;
+  rowGap?: GapSize;
+}
+
+const Grid = React.forwardRef<HTMLDivElement, GridProps>(
+  ({ className, cols, gap, columnGap, rowGap, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        gridVariants({
+          gap: gap ?? "none",
+          columnGap: columnGap ?? "none",
+          rowGap: rowGap ?? "none",
+        }),
+        gridTemplateColsClass(cols),
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Grid.displayName = "Grid";
+
+export { Grid, gridVariants };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -2,6 +2,7 @@ export * from "./accordion";
 export * from "./badge";
 export * from "./button";
 export * from "./date-picker";
+export * from "./divider";
 export * from "./flex";
 export * from "./input";
 export * from "./item";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,6 +4,7 @@ export * from "./button";
 export * from "./date-picker";
 export * from "./flex";
 export * from "./input";
+export * from "./item";
 export * from "./select";
 export * from "./skeleton";
 export * from "./stack";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -2,13 +2,21 @@ export * from "./accordion";
 export * from "./badge";
 export * from "./button";
 export * from "./date-picker";
+export * from "./flex";
 export * from "./input";
 export * from "./select";
 export * from "./skeleton";
+export * from "./stack";
 export * from "./switch";
 export * from "./tabs";
 export * from "./toggle-group";
 export * from "./tooltip";
 export * from "./utils/cn";
 export * from "./utils/date";
+export {
+  GAP_SEMANTIC,
+  GAP_X_SEMANTIC,
+  GAP_Y_SEMANTIC,
+  type GapSize,
+} from "./utils/gap-scale";
 export * from "./weekly-bar-chart";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,6 +5,7 @@ export * from "./button";
 export * from "./date-picker";
 export * from "./divider";
 export * from "./flex";
+export * from "./grid";
 export * from "./input";
 export * from "./item";
 export * from "./select";
@@ -22,4 +23,9 @@ export {
   GAP_Y_SEMANTIC,
   type GapSize,
 } from "./utils/gap-scale";
+export {
+  type GridColumnCount,
+  type GridTemplateColsBreakpoints,
+  gridTemplateColsClass,
+} from "./utils/grid-template-cols";
 export * from "./weekly-bar-chart";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -2,6 +2,7 @@ export * from "./accordion";
 export * from "./avatar";
 export * from "./badge";
 export * from "./button";
+export * from "./card";
 export * from "./date-picker";
 export * from "./divider";
 export * from "./flex";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./accordion";
+export * from "./avatar";
 export * from "./badge";
 export * from "./button";
 export * from "./date-picker";

--- a/packages/ui/src/item.tsx
+++ b/packages/ui/src/item.tsx
@@ -71,6 +71,19 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>(
 );
 Item.displayName = "Item";
 
+const ItemGroup = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div">
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-slot="item-group"
+    className={cn("flex w-full min-w-0 flex-col", className)}
+    {...props}
+  />
+));
+ItemGroup.displayName = "ItemGroup";
+
 export interface ItemMediaProps
   extends
     React.ComponentPropsWithoutRef<"div">,
@@ -146,6 +159,7 @@ export {
   ItemActions,
   ItemContent,
   ItemDescription,
+  ItemGroup,
   ItemMedia,
   itemMediaVariants,
   ItemTitle,

--- a/packages/ui/src/item.tsx
+++ b/packages/ui/src/item.tsx
@@ -1,0 +1,153 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "./utils/cn";
+
+const itemVariants = cva("group/item flex w-full flex-wrap items-center", {
+  variants: {
+    variant: {
+      default: "",
+      outline: "",
+      muted: "",
+    },
+    size: {
+      default: "gap-4 p-4",
+      sm: "gap-2.5 px-4 py-3",
+      xs: "gap-2 px-3 py-2",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+    size: "default",
+  },
+});
+
+const itemMediaVariants = cva(
+  "flex shrink-0 items-center justify-center gap-2 group-has-[[data-slot=item-description]]/item:translate-y-0.5 group-has-[[data-slot=item-description]]/item:self-start [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "",
+        icon: "size-8 items-center justify-center [&_svg:not([class*='size-'])]:size-4",
+        image:
+          "size-10 shrink-0 overflow-hidden [&_img]:size-full [&_img]:object-cover",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export type ItemProps = Omit<React.ComponentPropsWithoutRef<"div">, "size"> &
+  VariantProps<typeof itemVariants> & {
+    asChild?: boolean;
+  };
+
+const Item = React.forwardRef<HTMLDivElement, ItemProps>(
+  (
+    {
+      className,
+      variant = "default",
+      size = "default",
+      asChild = false,
+      ...props
+    },
+    ref,
+  ) => {
+    const Comp = asChild ? Slot : "div";
+    return (
+      <Comp
+        ref={ref}
+        data-slot="item"
+        data-variant={variant}
+        data-size={size}
+        className={cn(itemVariants({ variant, size }), className)}
+        {...props}
+      />
+    );
+  },
+);
+Item.displayName = "Item";
+
+export interface ItemMediaProps
+  extends
+    React.ComponentPropsWithoutRef<"div">,
+    VariantProps<typeof itemMediaVariants> {}
+
+const ItemMedia = React.forwardRef<HTMLDivElement, ItemMediaProps>(
+  ({ className, variant = "default", ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="item-media"
+      data-variant={variant}
+      className={cn(itemMediaVariants({ variant }), className)}
+      {...props}
+    />
+  ),
+);
+ItemMedia.displayName = "ItemMedia";
+
+const ItemContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div">
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-slot="item-content"
+    className={cn("flex min-w-0 flex-1 flex-col gap-1", className)}
+    {...props}
+  />
+));
+ItemContent.displayName = "ItemContent";
+
+const ItemTitle = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div">
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-slot="item-title"
+    className={cn("break-words text-subtitle-1-md text-gray-800", className)}
+    {...props}
+  />
+));
+ItemTitle.displayName = "ItemTitle";
+
+const ItemDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.ComponentPropsWithoutRef<"p">
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    data-slot="item-description"
+    className={cn("min-w-0", className)}
+    {...props}
+  />
+));
+ItemDescription.displayName = "ItemDescription";
+
+const ItemActions = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div">
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-slot="item-actions"
+    className={cn("flex shrink-0 flex-wrap items-center gap-2", className)}
+    {...props}
+  />
+));
+ItemActions.displayName = "ItemActions";
+
+export {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  itemMediaVariants,
+  ItemTitle,
+  itemVariants,
+};

--- a/packages/ui/src/stack.tsx
+++ b/packages/ui/src/stack.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "./utils/cn";
+import { GAP_SEMANTIC, type GapSize } from "./utils/gap-scale";
+
+const stackVariants = cva("flex flex-col", {
+  variants: {
+    align: {
+      stretch: "items-stretch",
+      center: "items-center",
+      "flex-start": "items-start",
+      "flex-end": "items-end",
+    },
+    justify: {
+      "flex-start": "justify-start",
+      center: "justify-center",
+      "flex-end": "justify-end",
+      "space-between": "justify-between",
+      "space-around": "justify-around",
+    },
+    gap: GAP_SEMANTIC,
+  },
+  defaultVariants: {
+    align: "stretch",
+    justify: "flex-start",
+    gap: "md",
+  },
+});
+
+export interface StackProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "size"
+> {
+  align?: VariantProps<typeof stackVariants>["align"];
+  justify?: VariantProps<typeof stackVariants>["justify"];
+  gap?: GapSize;
+}
+
+const Stack = React.forwardRef<HTMLDivElement, StackProps>(
+  ({ className, align, justify, gap, ...props }, ref) => {
+    const gapStep = gap ?? "md";
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          stackVariants({ align, justify, gap: gapStep }),
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Stack.displayName = "Stack";
+
+export { Stack, stackVariants };

--- a/packages/ui/src/utils/gap-scale.ts
+++ b/packages/ui/src/utils/gap-scale.ts
@@ -1,0 +1,29 @@
+/** Flex / Stack 공통 간격 단계(Mantine-style) */
+export const GAP_SEMANTIC = {
+  none: "",
+  xs: "gap-2.5",
+  sm: "gap-3",
+  md: "gap-4",
+  lg: "gap-5",
+  xl: "gap-8",
+} as const;
+
+export const GAP_X_SEMANTIC = {
+  none: "",
+  xs: "gap-x-2.5",
+  sm: "gap-x-3",
+  md: "gap-x-4",
+  lg: "gap-x-5",
+  xl: "gap-x-8",
+} as const;
+
+export const GAP_Y_SEMANTIC = {
+  none: "",
+  xs: "gap-y-2.5",
+  sm: "gap-y-3",
+  md: "gap-y-4",
+  lg: "gap-y-5",
+  xl: "gap-y-8",
+} as const;
+
+export type GapSize = keyof typeof GAP_SEMANTIC;

--- a/packages/ui/src/utils/grid-template-cols.ts
+++ b/packages/ui/src/utils/grid-template-cols.ts
@@ -1,0 +1,41 @@
+import { cn } from "./cn";
+
+export type GridColumnCount = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+
+export interface GridTemplateColsBreakpoints {
+  base?: GridColumnCount;
+  sm?: GridColumnCount;
+  md?: GridColumnCount;
+  lg?: GridColumnCount;
+  xl?: GridColumnCount;
+}
+
+const BP_PREFIX = {
+  base: "",
+  sm: "sm:",
+  md: "md:",
+  lg: "lg:",
+  xl: "xl:",
+} as const;
+
+function colsSegment(bp: keyof typeof BP_PREFIX, n: GridColumnCount): string {
+  return `${BP_PREFIX[bp]}grid-cols-${n}`;
+}
+
+export function gridTemplateColsClass(
+  cols: GridColumnCount | GridTemplateColsBreakpoints | undefined,
+): string {
+  if (cols === undefined) {
+    return colsSegment("base", 1);
+  }
+  if (typeof cols === "number") {
+    return colsSegment("base", cols);
+  }
+  return cn(
+    colsSegment("base", cols.base ?? 1),
+    cols.sm !== undefined && colsSegment("sm", cols.sm),
+    cols.md !== undefined && colsSegment("md", cols.md),
+    cols.lg !== undefined && colsSegment("lg", cols.lg),
+    cols.xl !== undefined && colsSegment("xl", cols.xl),
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,6 +426,9 @@ importers:
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-avatar':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1654,6 +1657,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-avatar@1.1.11':
+    resolution: {integrity: sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collapsible@1.1.12':
     resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
     peerDependencies:
@@ -1691,6 +1707,15 @@ packages:
 
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.3':
+    resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1816,6 +1841,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
@@ -1844,6 +1882,15 @@ packages:
 
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1945,6 +1992,15 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -5827,6 +5883,19 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
+  '@radix-ui/react-avatar@1.1.11(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.2(@types/react@19.2.2)
+
   '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -5862,6 +5931,12 @@ snapshots:
       '@types/react': 19.2.2
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.2
+
+  '@radix-ui/react-context@1.1.3(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       react: 19.2.0
     optionalDependencies:
@@ -5980,6 +6055,15 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.2(@types/react@19.2.2)
+
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -6027,6 +6111,13 @@ snapshots:
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.2
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
       react: 19.2.0
@@ -6135,6 +6226,13 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.2.0)
       react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.2
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+      use-sync-external-store: 1.6.0(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,6 +432,9 @@ importers:
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.3
+        version: 1.2.3(@types/react@19.2.2)(react@19.2.0)
       '@radix-ui/react-switch':
         specifier: ^1.2.6
         version: 1.2.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)


### PR DESCRIPTION


## 작업 내용



- **`Card`** (`card.tsx`): `Card` · `CardHeader` · `CardTitle` · `CardDescription` · `CardContent` · `CardFooter`, `variant` (`default` / `bordered` / `elevated`). 카드 패널의 패딩·타이포를 구역별로 분리해 **선언적 조립** 가능. Radix에는 전용 카드 패키지가 없어 **`@radix-ui/react-slot`**으로 root에만 `asChild` 합성.
- **`Item` / `ItemGroup`** (`item.tsx`): 리스트 행·설정 패널 등에서 재사용. `ItemGroup`으로 **같은 계층의 여러 `Item`을 묶는 컨테이너** 역할 명시 (`data-slot` 일관 적용).
- **레이아웃 원시(primitive)**: **`Flex`** · **`Stack`** · **`Grid`**, 디자인 시스템과 맞춘 **`Divider`**, **`Avatar`**.
- **간격·그리드 유틸**: `GAP_*` 계열 및 **`grid-template-cols`** 타입 헬퍼 등으로 레이아웃 클래스 문자열 분산 감소.



## 작업 목적

1. **스타일 출처 단일화**: 패널 라운드·배경·타이포·간격 등을 카드/`Item`/레이아웃 primitive 한쪽에서 규격화해, 페이지마다 `className` 문자열 중복과 미세 차이 축소.
2. **선언형 구조**: 헤더·본문·푸터, 리스트 그룹·행처럼 **역할별 슬롯**으로 JSX를 읽기 쉽게 하고 디자인 합치기를 단순화.
3. **유지 보수 비용 축소**: 테마나 스페이싱 변경 시 디자인 토큰·공통 컴포넌트만 조정하면 다수 화면에 반영되도록 기반 확보.



