### PR TITLE
feat: GA Web analytics 이벤트 수집 연동

### DIFF
--- a/apps/web/src/app/providers/analytics/AnalyticsPageTracker.tsx
+++ b/apps/web/src/app/providers/analytics/AnalyticsPageTracker.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+import { buildPageViewParams, useAnalytics } from "@/shared/lib/analytics";
+
+function AnalyticsPageTracker() {
+  const pathname = usePathname() ?? "/";
+  const searchParams = useSearchParams();
+  const { pageView } = useAnalytics();
+
+  const lastPathRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const search = searchParams?.toString() ?? "";
+    const pathKey = search ? `${pathname}?${search}` : pathname;
+
+    if (lastPathRef.current === pathKey) return;
+    lastPathRef.current = pathKey;
+
+    pageView(buildPageViewParams(pathname, search));
+  }, [pathname, searchParams]);
+
+  return null;
+}
+
+export default AnalyticsPageTracker;

--- a/apps/web/src/app/providers/analytics/AnalyticsProvider.tsx
+++ b/apps/web/src/app/providers/analytics/AnalyticsProvider.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { type ReactNode, useMemo } from "react";
+import { type ReactNode, Suspense, useMemo } from "react";
 import type { AnalyticsClient } from "@recap/analytics";
 
 import { AnalyticsContext, gtagAnalytics } from "@/shared/lib/analytics";
+
+import AnalyticsPageTracker from "./AnalyticsPageTracker";
 
 const AnalyticsProvider = ({
   children,
@@ -16,6 +18,9 @@ const AnalyticsProvider = ({
 
   return (
     <AnalyticsContext.Provider value={value}>
+      <Suspense fallback={null}>
+        <AnalyticsPageTracker />
+      </Suspense>
       {children}
     </AnalyticsContext.Provider>
   );

--- a/apps/web/src/entities/login/model/use-google-token-login.ts
+++ b/apps/web/src/entities/login/model/use-google-token-login.ts
@@ -5,6 +5,7 @@ import { catchAPIError } from "@recap/api";
 
 import { authAPIService } from "@/entities/auth/api";
 import { tokenStore } from "@/entities/auth/model/token-store";
+import { useAnalytics } from "@/shared/lib/analytics";
 
 type LoginResponse = {
   accessToken: string;
@@ -17,6 +18,7 @@ type UseGoogleTokenLoginOptions = {
 
 export function useGoogleTokenLogin(options?: UseGoogleTokenLoginOptions) {
   const { onLoginSuccess } = options ?? {};
+  const { track } = useAnalytics();
 
   const [ready, setReady] = useState(false);
 
@@ -74,9 +76,14 @@ export function useGoogleTokenLogin(options?: UseGoogleTokenLoginOptions) {
               refreshToken: data.refreshToken,
             });
 
+            track("login", { method: "google" });
             await onLoginSuccess?.();
           } catch (e: unknown) {
             catchAPIError(e);
+            track("web_error", {
+              where: "google_token_login",
+              message: e instanceof Error ? e.message : undefined,
+            });
           }
         },
       });

--- a/apps/web/src/entities/login/ui/LogoutButton.tsx
+++ b/apps/web/src/entities/login/ui/LogoutButton.tsx
@@ -8,12 +8,14 @@ import { tokenStore } from "@/entities/auth/model/token-store";
 import { useAuth } from "@/entities/auth/ui";
 import { USER_KEYS } from "@/features/settings/api/query-keys";
 import RightIcon from "@/shared/assets/icons/arrow-right.svg";
+import { useAnalytics } from "@/shared/lib/analytics";
 
 const LogoutButton = () => {
   const { t } = useLocale("settings");
 
   const { refreshAuth } = useAuth();
   const queryClient = useQueryClient();
+  const analytics = useAnalytics();
 
   const handleLogout = async () => {
     try {
@@ -25,11 +27,17 @@ const LogoutButton = () => {
         tokenStore.set({ accessToken: "", refreshToken: "" });
       }
 
+      analytics.identify(null);
+      analytics.track("logout", {});
       refreshAuth();
       await queryClient.resetQueries({ queryKey: USER_KEYS.details() });
       await queryClient.invalidateQueries({ queryKey: USER_KEYS.details() });
     } catch (err) {
       catchAPIError(err);
+      analytics.track("web_error", {
+        where: "logout",
+        message: err instanceof Error ? err.message : undefined,
+      });
     }
   };
 

--- a/apps/web/src/shared/lib/analytics/build-page-view-params.ts
+++ b/apps/web/src/shared/lib/analytics/build-page-view-params.ts
@@ -1,0 +1,19 @@
+import type { AnalyticsEventMap } from "@recap/analytics";
+import { pageLocationOriginOnly } from "@recap/analytics";
+
+export function buildPageViewParams(
+  pathname: string,
+  search: string,
+): AnalyticsEventMap["page_view"] {
+  const pagePath = search ? `${pathname}?${search}` : pathname;
+  const href =
+    typeof window !== "undefined"
+      ? window.location.href
+      : `https://localhost${pagePath}`;
+
+  return {
+    page_title: typeof document !== "undefined" ? (document.title ?? "") : "",
+    page_location: pageLocationOriginOnly(href),
+    page_path: pagePath,
+  };
+}

--- a/apps/web/src/shared/lib/analytics/gtag-client.ts
+++ b/apps/web/src/shared/lib/analytics/gtag-client.ts
@@ -1,8 +1,8 @@
 import type {
   AnalyticsClient,
   AnalyticsEventMap,
-  AnalyticsEventName,
   AnalyticsParams,
+  AnalyticsTrackEventName,
 } from "@recap/analytics";
 
 import { isDev } from "@/shared/config";
@@ -36,7 +36,10 @@ export const gtagAnalytics: AnalyticsClient = {
     send("config", analyticsMeasurementId, config);
   },
 
-  track<E extends AnalyticsEventName>(name: E, params: AnalyticsEventMap[E]) {
+  track<E extends AnalyticsTrackEventName>(
+    name: E,
+    params: AnalyticsEventMap[E],
+  ) {
     send("event", name, params);
   },
 

--- a/apps/web/src/shared/lib/analytics/index.ts
+++ b/apps/web/src/shared/lib/analytics/index.ts
@@ -3,4 +3,3 @@ export * from "./build-page-view-params";
 export * from "./env";
 export * from "./gtag-client";
 export * from "./use-analytics";
-export * from "./use-track-recap-generated";

--- a/apps/web/src/shared/lib/analytics/index.ts
+++ b/apps/web/src/shared/lib/analytics/index.ts
@@ -1,4 +1,6 @@
 export * from "./analytics-context";
+export * from "./build-page-view-params";
 export * from "./env";
 export * from "./gtag-client";
 export * from "./use-analytics";
+export * from "./use-track-recap-generated";

--- a/apps/web/src/shared/lib/analytics/use-analytics.ts
+++ b/apps/web/src/shared/lib/analytics/use-analytics.ts
@@ -1,10 +1,47 @@
 "use client";
 
-import { useContext } from "react";
-import type { AnalyticsClient } from "@recap/analytics";
+import { useContext, useMemo } from "react";
+import type {
+  AnalyticsClient,
+  AnalyticsEventMap,
+  AnalyticsTrackEventName,
+} from "@recap/analytics";
+import { createParamsEnricher } from "@recap/analytics";
+
+import { useLanguageStore } from "@/entities/language";
 
 import { AnalyticsContext } from "./analytics-context";
 
+const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.1.0";
+
 export function useAnalytics(): AnalyticsClient {
-  return useContext(AnalyticsContext);
+  const client = useContext(AnalyticsContext);
+  const locale = useLanguageStore((s) => s.localize);
+
+  return useMemo(() => {
+    const enrich = createParamsEnricher(() => ({
+      platform: "web" as const,
+      app_version: APP_VERSION,
+      locale,
+    }));
+
+    return {
+      platform: client.platform,
+
+      identify(userId, traits) {
+        return client.identify(userId, traits ? enrich(traits) : undefined);
+      },
+
+      track<E extends AnalyticsTrackEventName>(
+        name: E,
+        params: AnalyticsEventMap[E],
+      ) {
+        return client.track(name, enrich(params));
+      },
+
+      pageView(params: AnalyticsEventMap["page_view"]) {
+        return client.pageView(enrich(params));
+      },
+    } satisfies AnalyticsClient;
+  }, [client, locale]);
 }


### PR DESCRIPTION
## 작업 내용
- 공통 @recap/analytics 모듈을 web 앱 환경에 맞게 감싸는 useAnalytics adapter hook을 구성했습니다.
- 아래 이벤트 별 google analytics 데이터 수집 가능하도록 구현했습니다. 

이벤트 | 수집 위치 | 설명
-- | -- | --
page_view | AnalyticsPageTracker | 경로 변경 시 1회 전송
login | useGoogleTokenLogin | OAuth 성공 시 전송
logout | LogoutButton | 로그아웃 성공 시 전송 및 identify(null) 호출
web_error | Google 로그인 실패, 로그아웃 실패, AI recap fetch 실패 | web 주요 실패 케이스 수집



## 작업 목적
- 비즈니스 코드에서 analytics client 구현 세부사항을 직접 알지 않아도 useAnalytics()만으로 이벤트를 수집할 수 있도록 개선했습니다.
- web 앱에서 필요한 platform, app_version, locale 등의 공통 메타데이터 주입을 중앙화했습니다.
- page view, login, logout, error 이벤트 수집 흐름을 GA Web에 연결해 사용자 행동 및 주요 실패 케이스를 추적할 수 있도록 했습니다.
