### PR TITLE
feat(extension): 알람 기반 세션 재시작 처리 추가

### DIFF
--- a/apps/extension/src/app/entrypoint/background/index.ts
+++ b/apps/extension/src/app/entrypoint/background/index.ts
@@ -27,6 +27,121 @@ chrome.sidePanel
   .setPanelBehavior({ openPanelOnActionClick: true })
   .catch((error: unknown) => console.error(error));
 
+const TEST_ALARM_NAME = "test-console-log-alarm";
+
+const TARGET_HOUR = 0;
+const TARGET_MINUTE = 0;
+
+const getNextAlarmTime = (hour: number, minute: number) => {
+  const now = new Date();
+  const target = new Date();
+
+  target.setHours(hour, minute, 0, 0);
+
+  if (target.getTime() <= now.getTime()) {
+    target.setDate(target.getDate() + 1);
+  }
+
+  return target.getTime();
+};
+
+const ensureTestAlarm = async () => {
+  await browser.alarms.clear(TEST_ALARM_NAME);
+
+  const scheduledTime = getNextAlarmTime(TARGET_HOUR, TARGET_MINUTE);
+
+  await browser.alarms.create(TEST_ALARM_NAME, {
+    when: scheduledTime,
+  });
+};
+
+const getCurrentActiveTab = async () => {
+  const [lastFocusedActiveTab] = await browser.tabs.query({
+    active: true,
+    lastFocusedWindow: true,
+  });
+
+  if (lastFocusedActiveTab?.id != null) {
+    return lastFocusedActiveTab;
+  }
+
+  const [anyActiveTab] = await browser.tabs.query({
+    active: true,
+  });
+
+  return anyActiveTab;
+};
+
+const runScheduledSessionRestart = async () => {
+  try {
+    const activeTab = await getCurrentActiveTab();
+
+    const activeTabId = activeTab?.id;
+
+    if (activeTabId == null) {
+      console.warn("[alarm] active tab id not found");
+      return;
+    }
+
+    const currentSession = await getBrowserSessionById(String(activeTabId));
+
+    if (!currentSession) {
+      console.warn("[alarm] current browser session not found", {
+        tabId: activeTabId,
+      });
+      return;
+    }
+
+    /**
+     * createClosedHistory는 session.closedAt이 있으면 return 하므로
+     * closedAt 없는 원본 session으로 호출
+     */
+    const sessionForClosedHistory = {
+      ...currentSession,
+      tabId: Number(activeTabId),
+    } as StorageSession;
+
+    browserHistory.createClosedHistory(sessionForClosedHistory);
+
+    /**
+     * 실제 현재 session close 처리
+     */
+    const closedSession = await closeBrowserSession();
+
+    const closedAt = closedSession?.closedAt ?? new Date().getTime() / 1000;
+
+    /**
+     * createHistory는 visitedAt, closedAt으로 시간 차이를 계산하므로
+     * closedAt이 있는 동일 session을 넘김
+     */
+    const sessionForHistory = {
+      ...currentSession,
+      ...(closedSession ?? {}),
+      tabId: Number(activeTabId),
+      closedAt,
+    } as StorageSession;
+
+    browserHistory.createHistory(sessionForHistory);
+
+    /**
+     * 같은 탭을 다시 start 상태로 전환
+     */
+    await visitBrowserSession(String(activeTabId));
+  } catch (error) {
+    console.error("[alarm] runScheduledSessionRestart failed", error);
+  }
+};
+
+browser.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name !== TEST_ALARM_NAME) return;
+
+  runScheduledSessionRestart().catch((error) => {
+    console.error("[alarm] unhandled restart error", error);
+  });
+});
+
+void ensureTestAlarm();
+
 browser.runtime.onInstalled.addListener((details) => {
   void analytics.fireEvent("extension_lifecycle", {
     reason: details.reason,
@@ -91,12 +206,10 @@ browser.runtime.onMessage.addListener(
       }
 
       await addBrowserSession(String(sender.tab?.id ?? ""), msg.data);
-      try {
-        const host = new URL(msg.data.url).host;
-        void analytics.fireEvent("content_session_tracked", { host });
-      } catch {
-        /* invalid URL — skip GA */
-      }
+
+      const host = new URL(msg.data.url).host;
+      void analytics.fireEvent("content_session_tracked", { host });
+
       return;
     }
 

--- a/apps/extension/src/manifest.config.ts
+++ b/apps/extension/src/manifest.config.ts
@@ -9,7 +9,7 @@ export function createManifest(env: Record<string, string>): ManifestV3Export {
     version,
     description: "Retoday Extension",
     ...(env.VITE_EXTENSION_KEY && { key: env.VITE_EXTENSION_KEY }),
-    permissions: ["tabs", "storage", "sidePanel", "identity"],
+    permissions: ["tabs", "storage", "sidePanel", "identity", "alarms"],
     action: {
       default_icon: {
         "128": "src/shared/assets/icons/favicon-128.png",


### PR DESCRIPTION
## 작업 내용

- 브라우저 확장 프로그램에 자정 기준으로 실행되는 alarms 기반 스케줄링 로직을 추가했습니다.
- 자정 시점에 현재 활성 세션을 종료 처리하고, 동일 세션 정보로 히스토리를 생성하도록 구성했습니다.
- 종료 이후 동일 탭을 다시 방문 상태로 전환해 자정 이후 사용 시간이 새로운 세션으로 기록되도록 처리했습니다.


## 작업 목적

- 자정을 넘겨 동일 탭을 계속 사용하는 경우에도 일별 세션 기록이 분리되도록 개선했습니다.
- Manifest V3 환경에서 service worker 중단 영향을 줄이기 위해 setTimeout 대신 alarms API를 사용했습니다.
- 일별 사용 기록과 리캡 데이터가 자정 기준으로 더 정확하게 집계될 수 있도록 정리했습니다.
