### PR TITLE
feat: 익스텐션 browser 히스토리 생성 DTO 변경

### DIFF
--- a/apps/extension/src/entities/history/model/browser-history.ts
+++ b/apps/extension/src/entities/history/model/browser-history.ts
@@ -3,6 +3,7 @@ import { calculateTimeDiff } from "@recap/lib";
 import { historyAPIService } from "@/entities/history/api";
 import type { CreateHistoryDTO } from "@/entities/history/model/history.type";
 import type { StorageSession } from "@/entities/history/model/storage.type";
+import { CURRENT_LOCATION } from "@/shared/config/location";
 import { extractDomainUrl } from "@/shared/lib/url";
 
 const browserHistory = {
@@ -17,9 +18,13 @@ const browserHistory = {
     }
     console.log("createClosedHistory");
     historyAPIService.createHistory({
-      ...session,
       url: extractDomainUrl(session.url),
+      visitedAt: session.visitedAt,
       closedAt,
+      timeZone: CURRENT_LOCATION,
+      title: session.title,
+      description: session.metadata.description,
+      faviconUrl: session.metadata.faviconUrl,
       isClosed: true,
     } as CreateHistoryDTO);
   },
@@ -32,8 +37,13 @@ const browserHistory = {
     }
     console.log("createHistory");
     historyAPIService.createHistory({
-      ...session,
       url: extractDomainUrl(session.url),
+      visitedAt: session.visitedAt,
+      closedAt: session.closedAt,
+      timeZone: CURRENT_LOCATION,
+      title: session.title,
+      description: session.metadata.description,
+      faviconUrl: session.metadata.faviconUrl,
       isClosed: false,
     } as CreateHistoryDTO);
   },

--- a/apps/extension/src/entities/history/model/history.type.ts
+++ b/apps/extension/src/entities/history/model/history.type.ts
@@ -1,13 +1,11 @@
 export type CreateHistoryDTO = {
-  tabId: number;
   url: string;
   visitedAt: number;
   closedAt: number;
+  timeZone: string;
   title: string;
-  metadata: {
-    description: string;
-    faviconUrl: string;
-  };
+  description: string;
+  faviconUrl: string;
   isClosed: boolean;
   scrollDepth?: number;
 };


### PR DESCRIPTION
## 작업 내용

- `history` POST 생성 payload의 `CreateHistoryDTO` 타입 구조를 변경했습니다.
- 탭 식별용으로 사용하던 `tabId` 필드를 제거했습니다.
- `metadata.description`, `metadata.faviconUrl` 형태의 중첩 필드를 `description`, `faviconUrl` 최상위 필드로 평탄화했습니다.
- 사용자의 방문 시각 기준을 명확히 전달할 수 있도록 `timeZone` 필드를 추가했습니다.
- `url`, `visitedAt`, `closedAt`, `title`, `isClosed`, `scrollDepth` 등 기존 히스토리 생성에 필요한 기본 필드는 유지했습니다.

## 작업 목적

- 백엔드 history 생성 API의 변경된 요청 스펙에 맞춰 클라이언트 payload 타입을 정리하고, 히스토리 생성 요청 데이터 구조를 더 단순하고 명확하게 관리하기 위함입니다.

