### PR TITLE
fix(extension): extension 릴리스 CI 빌드 스크립트 누락 수정

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Zip build output
         run: |
+          test -d apps/extension/dist/chrome || (echo "Build output not found at apps/extension/dist/chrome" && exit 1)
           cd apps/extension/dist/chrome
           zip -r ../../../../retoday-extension-v${{ steps.version.outputs.tag }}.zip .
 

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -6,6 +6,7 @@
   "description": "Chrome Extension - Browser Recap",
   "scripts": {
     "dev": "vite build --watch --mode development",
+    "build": "vite build --mode production",
     "build:dev": "vite build --mode development",
     "build:prod": "vite build --mode production",
     "build:chrome": "vite build --mode production --browser=chrome",


### PR DESCRIPTION
## 작업 내용

- `apps/extension/package.json`에 `build` 스크립트 추가 (`vite build --mode production`)
- `release-extension.yml` zip 단계 전 `dist/chrome` 존재 여부 검증 추가

## 작업 목적

`extension@*` 태그 push 시 GitHub Actions가 `pnpm --filter extension build`를 실행하지만, extension 패키지에 `build` 스크립트가 없어 빌드가 건너뛰어지고 `apps/extension/dist/chrome`이 생성되지 않던 문제를 해결합니다.

pnpm은 스크립트가 없을 때 exit code 0으로 통과하므로, zip 단계에서 `cd apps/extension/dist/chrome` 실패가 발생했습니다.

### 스크린샷 (선택)

N/A

## Test plan

- [ ] `pnpm --filter extension build` 실행 후 `apps/extension/dist/chrome` 생성 확인
- [ ] `extension@*` 태그 push 후 GitHub Actions 릴리스 워크플로우 성공 확인


Made with [Cursor](https://cursor.com)

