### PR TITLE
fix(web): 인증 재발급 후 API 재호출 실패 및 로그인 조건 수정

### DIFF
--- a/apps/web/app/analysis/error.tsx
+++ b/apps/web/app/analysis/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import AnalysisUnloginPage from "@/pages/analysis/ui/AnalysisUnloginPage";
+
+export default function Error() {
+  return <AnalysisUnloginPage />;
+}

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -50,7 +50,11 @@ export async function POST(req: Request) {
       oAuthToken: body.oAuthToken,
     });
 
-    return NextResponse.json({ ok: true });
+    return NextResponse.json({
+      ok: true,
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+    });
   } catch (error) {
     return NextResponse.json(
       {

--- a/apps/web/app/api/auth/refresh/route.ts
+++ b/apps/web/app/api/auth/refresh/route.ts
@@ -2,9 +2,17 @@ import { NextResponse } from "next/server";
 
 import { refreshAuthTokens } from "@/entities/auth/lib/refresh-auth-tokens";
 
-export async function POST() {
+type RefreshRequest = {
+  refreshToken?: string;
+};
+
+export async function POST(req: Request) {
   try {
-    const refreshed = await refreshAuthTokens();
+    const body = (await req.json().catch(() => ({}))) as RefreshRequest;
+    const refreshToken =
+      typeof body.refreshToken === "string" ? body.refreshToken : undefined;
+
+    const refreshed = await refreshAuthTokens("v1", refreshToken);
 
     if (!refreshed) {
       return NextResponse.json({ message: "Unauthorized" }, { status: 401 });

--- a/apps/web/app/api/auth/session/route.ts
+++ b/apps/web/app/api/auth/session/route.ts
@@ -3,9 +3,18 @@ import { NextResponse } from "next/server";
 import { serverTokenStore } from "@/entities/auth/model/server-token-store";
 
 export async function GET() {
-  const isLoggedIn = await serverTokenStore.hasRefresh();
+  const tokens = await serverTokenStore.get();
+  const isLoggedIn = Boolean(tokens.refreshToken);
 
-  return NextResponse.json({ isLoggedIn });
+  if (!isLoggedIn) {
+    return NextResponse.json({ isLoggedIn: false });
+  }
+
+  return NextResponse.json({
+    isLoggedIn: true,
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+  });
 }
 
 export async function DELETE() {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -55,18 +55,18 @@ export default async function RootLayout({
     >
       <body className="min-h-screen w-[min(100%,80rem)] bg-gray-100">
         <ReactQueryProvider>
-          <LanguageProvider>
-            <AnalyticsProvider>
-              <AuthProvider>
+          <AuthProvider>
+            <LanguageProvider>
+              <AnalyticsProvider>
                 <MainLayout>
                   <Suspense>
                     <MainHeader />
                   </Suspense>
                   {children}
                 </MainLayout>
-              </AuthProvider>
-            </AnalyticsProvider>
-          </LanguageProvider>
+              </AnalyticsProvider>
+            </LanguageProvider>
+          </AuthProvider>
         </ReactQueryProvider>
         <AnalyticsScripts />
       </body>

--- a/apps/web/src/entities/auth/api/auth-session-client.ts
+++ b/apps/web/src/entities/auth/api/auth-session-client.ts
@@ -1,3 +1,5 @@
+import { clientTokenStore } from "@/entities/auth/model/client-token-store";
+
 type LoginPayload = {
   oAuthToken: string;
   provider: "GOOGLE";
@@ -5,6 +7,8 @@ type LoginPayload = {
 
 type SessionResponse = {
   isLoggedIn: boolean;
+  accessToken?: string;
+  refreshToken?: string;
 };
 
 async function parseError(res: Response) {
@@ -35,7 +39,19 @@ export async function loginWithOAuth(payload: LoginPayload) {
     await parseError(res);
   }
 
-  return res.json();
+  const body = (await res.json()) as {
+    accessToken?: string;
+    refreshToken?: string;
+  };
+
+  if (body.accessToken && body.refreshToken) {
+    clientTokenStore.set({
+      accessToken: body.accessToken,
+      refreshToken: body.refreshToken,
+    });
+  }
+
+  return body;
 }
 
 export async function logoutSession() {
@@ -49,10 +65,14 @@ export async function logoutSession() {
     await parseError(res);
   }
 
+  clientTokenStore.clear();
+
   return res.json();
 }
 
 export async function clearSession() {
+  clientTokenStore.clear();
+
   const res = await fetch("/api/auth/session", {
     method: "DELETE",
     credentials: "include",
@@ -95,5 +115,16 @@ export async function fetchSession(): Promise<SessionResponse> {
     return { isLoggedIn: false };
   }
 
-  return (await res.json()) as SessionResponse;
+  const session = (await res.json()) as SessionResponse;
+
+  if (session.isLoggedIn && session.accessToken && session.refreshToken) {
+    clientTokenStore.set({
+      accessToken: session.accessToken,
+      refreshToken: session.refreshToken,
+    });
+  } else {
+    clientTokenStore.clear();
+  }
+
+  return session;
 }

--- a/apps/web/src/entities/auth/lib/create-authed-rest.ts
+++ b/apps/web/src/entities/auth/lib/create-authed-rest.ts
@@ -1,20 +1,32 @@
 import type { RestAPIProtocol } from "@recap/api";
 import { RestAPI, RestAPIInstance } from "@recap/api";
 
-import { clearSession } from "@/entities/auth/api/auth-session-client";
+import {
+  clearSession,
+  fetchSession,
+} from "@/entities/auth/api/auth-session-client";
+import { clientTokenStore } from "@/entities/auth/model/client-token-store";
 
 const CLIENT_BFF_BASE_URL = "/api/backend";
 
 let refreshPromise: Promise<boolean> | null = null;
 
-async function refreshSession(): Promise<boolean> {
+async function refreshSession(refreshToken: string): Promise<boolean> {
   const res = await fetch("/api/auth/refresh", {
     method: "POST",
     credentials: "include",
-    headers: { Accept: "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ refreshToken }),
   });
 
-  return res.ok;
+  if (!res.ok) return false;
+
+  await fetchSession();
+
+  return true;
 }
 
 function isRefreshUrl(url: string) {
@@ -39,10 +51,13 @@ export function createAuthedRestAPI(
       if (res.status !== 401) return res;
       if (isRefreshUrl(url)) return res;
 
+      const refreshToken = clientTokenStore.getRefresh();
+      if (!refreshToken) return res;
+
       if (!refreshPromise) {
         refreshPromise = (async () => {
           try {
-            return await refreshSession();
+            return await refreshSession(refreshToken);
           } finally {
             refreshPromise = null;
           }

--- a/apps/web/src/entities/auth/lib/refresh-auth-tokens.ts
+++ b/apps/web/src/entities/auth/lib/refresh-auth-tokens.ts
@@ -29,8 +29,9 @@ async function requestRefresh(
 
 export async function refreshAuthTokens(
   apiBaseURL = "v1",
+  _refreshToken?: string,
 ): Promise<RefreshResponse | null> {
-  const refreshToken = await serverTokenStore.getRefresh();
+  const refreshToken = _refreshToken ?? (await serverTokenStore.getRefresh());
   if (!refreshToken) return null;
 
   const existing = refreshPromises.get(refreshToken);
@@ -39,7 +40,7 @@ export async function refreshAuthTokens(
   const promise = (async () => {
     try {
       const tokens = await requestRefresh(refreshToken, apiBaseURL);
-      await serverTokenStore.set(tokens);
+
       return tokens;
     } finally {
       refreshPromises.delete(refreshToken);

--- a/apps/web/src/entities/auth/model/client-token-store.ts
+++ b/apps/web/src/entities/auth/model/client-token-store.ts
@@ -1,0 +1,37 @@
+const ACCESS_TOKEN_KEY = "auth.accessToken";
+const REFRESH_TOKEN_KEY = "auth.refreshToken";
+
+type ClientAuthTokens = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+function canUseStorage() {
+  return typeof window !== "undefined";
+}
+
+export const clientTokenStore = {
+  getAccess(): string | null {
+    if (!canUseStorage()) return null;
+    return localStorage.getItem(ACCESS_TOKEN_KEY);
+  },
+
+  getRefresh(): string | null {
+    if (!canUseStorage()) return null;
+    return localStorage.getItem(REFRESH_TOKEN_KEY);
+  },
+
+  set(next: ClientAuthTokens) {
+    if (!canUseStorage()) return;
+
+    localStorage.setItem(ACCESS_TOKEN_KEY, next.accessToken);
+    localStorage.setItem(REFRESH_TOKEN_KEY, next.refreshToken);
+  },
+
+  clear() {
+    if (!canUseStorage()) return;
+
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
+    localStorage.removeItem(REFRESH_TOKEN_KEY);
+  },
+};

--- a/apps/web/src/entities/language/model/use-language.ts
+++ b/apps/web/src/entities/language/model/use-language.ts
@@ -1,6 +1,7 @@
 import type { LanguageType } from "@recap/i18n";
 import { DEFAULT_LANGUAGE } from "@recap/i18n";
 
+import { useAuth } from "@/entities/auth/ui";
 import { LANGUAGE_MAP } from "@/entities/language/config/language.const";
 import { useLanguageStore } from "@/entities/language/model/language.store";
 import { useGetUserProfile } from "@/features/settings/api/user-query.client";
@@ -8,9 +9,10 @@ import { useGetUserProfile } from "@/features/settings/api/user-query.client";
 const useLanguage = () => {
   const storedLanguage = useLanguageStore((s) => s.localize);
   const setLanguage = useLanguageStore((s) => s.setLanguage);
-
+  const { isLoggedIn } = useAuth();
   const { data: profileLanguage } = useGetUserProfile({
     select: (data) => data?.data?.language,
+    enabled: isLoggedIn,
   });
 
   const language: LanguageType = profileLanguage


### PR DESCRIPTION
## 작업 내용

- 클라이언트 토큰 저장소(`client-token-store`) 추가 
-  localStorage에 access/refresh 토큰 관리
- 로그인·세션 API 응답에 토큰 포함, 클라이언트에서 저장·동기화
- refresh API가 요청 body의 `refreshToken`을 받아 재발급 후 `fetchSession`으로 토큰 갱신
- `create-authed-rest` 401 인터셉터에서 refresh 토큰으로 재발급 후 원래 API 재호출
- `AuthProvider`를 `LanguageProvider`보다 상위로 이동해 인증 상태 기반 훅 사용 가능하도록 수정
- 유저 프로필 조회(`useGetUserProfile`)에 `enabled: isLoggedIn` 조건 추가
- analysis 페이지 미로그인 에러 UI(`error.tsx`) 추가

## 작업 목적

access token 만료 후 refresh로 재발급해도 클라이언트에 갱신된 토큰이 반영되지 않아 이후 API 호출이 계속 401로 실패하는 문제를 해결합니다. 또한 비로그인 상태에서 불필요한 유저 데이터 조회 API가 호출되지 않도록 합니다.

### 스크린샷 (선택)


Made with [Cursor](https://cursor.com)
