### PR TITLE
feat: ScreenTime 모드별 데이터 사전 로드 및 extension-web 자동 로그인 통합

### DIFF
--- a/apps/extension/src/features/analysis/api/analysis-query.ts
+++ b/apps/extension/src/features/analysis/api/analysis-query.ts
@@ -13,6 +13,18 @@ import { useQuery, type UseQueryOptions } from "@recap/react-query";
 import { analysisAPIService } from "@/features/analysis/api";
 import { ANALYSIS_KEYS } from "@/features/analysis/api/query-keys";
 
+export const screenTimeQueryOptions = (dateQuery: GetScreenTimeQueryType) => ({
+  queryKey: ANALYSIS_KEYS.screenTime([
+    dateQuery.period,
+    dateQuery.date,
+    dateQuery.timeZone,
+  ]),
+  queryFn: async () => {
+    const envelope = await analysisAPIService.getScreenTime(dateQuery);
+    return envelope.data;
+  },
+});
+
 export const useGetAnalysisScreenTime = <TData = AnalysisScreenTimeData>(
   dateQuery: GetScreenTimeQueryType,
   options?: Omit<
@@ -21,11 +33,7 @@ export const useGetAnalysisScreenTime = <TData = AnalysisScreenTimeData>(
   >,
 ) => {
   return useQuery<AnalysisScreenTimeData, Error, TData>({
-    queryKey: ANALYSIS_KEYS.screenTime([dateQuery.period, dateQuery.date]),
-    queryFn: async () => {
-      const envelope = await analysisAPIService.getScreenTime(dateQuery);
-      return envelope.data;
-    },
+    ...screenTimeQueryOptions(dateQuery),
     ...options,
   });
 };

--- a/apps/extension/src/features/analysis/ui/WeeklyScreenTimeSection.tsx
+++ b/apps/extension/src/features/analysis/ui/WeeklyScreenTimeSection.tsx
@@ -3,9 +3,10 @@ import type { ScreenTimePeriodType } from "@recap/api";
 import { toScreenTimeChartState } from "@recap/features";
 import { useLocale } from "@recap/i18n";
 import { formatDate, formatDuration } from "@recap/lib";
+import { useQueries } from "@recap/react-query";
 
 import useTimeZone from "@/entities/language/model/use-time-zone";
-import { useGetAnalysisScreenTime } from "@/features/analysis/api/analysis-query";
+import { screenTimeQueryOptions } from "@/features/analysis/api/analysis-query";
 import {
   SCREEN_TIME_MODE_CONFIG,
   SCREEN_TIME_PERIOD_LIST,
@@ -28,20 +29,29 @@ const WeeklyScreenTimeSection = () => {
   const date = formatDate(selectedDate, DATE_FORMAT.YYYY_MM_DD_DASH);
   const timeZone = useTimeZone();
 
-  const { data, isLoading } = useGetAnalysisScreenTime(
-    { date, period: mode, timeZone },
-    {
-      select: (screenTimeData) =>
-        toScreenTimeChartState({ data: screenTimeData, mode, date, t }),
-    },
-  );
+  const [
+    { data: daily, isLoading: isDailyLoading },
+    { data: weekly, isLoading: isWeeklyLoading },
+  ] = useQueries({
+    queries: [
+      screenTimeQueryOptions({ date, period: "DAILY", timeZone }),
+      screenTimeQueryOptions({ date, period: "WEEKLY", timeZone }),
+    ],
+  });
+
+  if (isDailyLoading || isWeeklyLoading || !daily || !weekly) {
+    return <WeeklyScreenTimeSectionSkeleton />;
+  }
+
+  const data = toScreenTimeChartState({
+    data: mode === "DAILY" ? daily : weekly,
+    mode,
+    date,
+    t,
+  });
 
   const isEmpty = data?.duration && data.duration <= 0;
   const modeConfig = SCREEN_TIME_MODE_CONFIG[mode];
-
-  if (isLoading) {
-    return <WeeklyScreenTimeSectionSkeleton />;
-  }
 
   return (
     <div className="w-full bg-white flex flex-col py-4 px-5">

--- a/apps/extension/src/widgets/layout/ui/SidePanelFooter.tsx
+++ b/apps/extension/src/widgets/layout/ui/SidePanelFooter.tsx
@@ -4,10 +4,26 @@ import { Button } from "@recap/ui";
 import browser from "webextension-polyfill";
 
 import { DATE_FORMAT, GNB_TABS, RETODAY_BASE_URL } from "@/shared/config";
-import { tokenStore } from "@/shared/lib/token-store";
 import { Icon } from "@/shared/ui";
 import { useDateSelectorStore } from "@/widgets/date-selector/model";
 import { useTabNavigationStore } from "@/widgets/tab-navigation/model";
+
+function getGoogleOAuthToken(interactive = false): Promise<string> {
+  return new Promise((resolve, reject) => {
+    chrome.identity.getAuthToken({ interactive }, (token) => {
+      if (chrome.runtime.lastError || !token) {
+        reject(
+          new Error(
+            chrome.runtime.lastError?.message ?? "Failed to get Google token",
+          ),
+        );
+        return;
+      }
+
+      resolve(token);
+    });
+  });
+}
 
 const SidePanelFooter = () => {
   const activeTab = useTabNavigationStore((state) => state.activeTab);
@@ -18,10 +34,17 @@ const SidePanelFooter = () => {
     const path =
       GNB_TABS.find((tab) => tab.value === activeTab)?.path ?? "/analysis";
     const date = formatDate(selectedDate, DATE_FORMAT.YYYY_MM_DD_DASH);
-    const refreshToken = (await tokenStore.getRefresh()) ?? "";
+
+    let oAuthToken: string;
+
+    try {
+      oAuthToken = await getGoogleOAuthToken(false);
+    } catch {
+      oAuthToken = await getGoogleOAuthToken(true);
+    }
 
     const params = new URLSearchParams({
-      code: refreshToken,
+      oAuthToken,
       redirect: path,
       date,
     });

--- a/apps/web/app/analysis/page.tsx
+++ b/apps/web/app/analysis/page.tsx
@@ -54,6 +54,11 @@ export default async function Page({ searchParams }: AnalysisRouteProps) {
                 period: "DAILY",
                 timeZone: SERVER_TIMEZONE.SEOUL,
               }),
+              serverScreenTimeQueryOptions({
+                date,
+                period: "WEEKLY",
+                timeZone: SERVER_TIMEZONE.SEOUL,
+              }),
             ]}
           >
             <ScreenTime date={date} />

--- a/apps/web/src/entities/login/model/use-google-token-login.ts
+++ b/apps/web/src/entities/login/model/use-google-token-login.ts
@@ -25,24 +25,26 @@ export function useGoogleTokenLogin(options?: UseGoogleTokenLoginOptions) {
     [],
   );
 
-  const login = () => {
-    void requestGoogleAccessToken()
-      .then(async (googleAccessToken) => {
-        await loginWithOAuth({
-          oAuthToken: googleAccessToken,
-          provider: "GOOGLE",
-        });
+  const login = async (oAuthToken?: string) => {
+    try {
+      const googleAccessToken =
+        oAuthToken ?? (await requestGoogleAccessToken());
 
-        track("login", { method: "google" });
-        await onLoginSuccess?.();
-      })
-      .catch((e: unknown) => {
-        catchAPIError(e);
-        track("web_error", {
-          where: "google_token_login",
-          message: e instanceof Error ? e.message : undefined,
-        });
+      await loginWithOAuth({
+        oAuthToken: googleAccessToken,
+        provider: "GOOGLE",
       });
+
+      track("login", { method: "google" });
+      await onLoginSuccess?.();
+    } catch (e: unknown) {
+      catchAPIError(e);
+      track("web_error", {
+        where: "google_token_login",
+        message: e instanceof Error ? e.message : undefined,
+      });
+      throw e;
+    }
   };
 
   useEffect(() => {

--- a/apps/web/src/entities/login/ui/LoginButton.tsx
+++ b/apps/web/src/entities/login/ui/LoginButton.tsx
@@ -32,7 +32,7 @@ const LoginButton = ({ className }: { className?: string }) => {
       type="button"
       variant="secondary"
       size="md"
-      onClick={login}
+      onClick={() => login()}
       disabled={!ready}
       className={cn("flex gap-2 px-4 py-2", className)}
     >

--- a/apps/web/src/features/analysis/api/analysis-query.client.ts
+++ b/apps/web/src/features/analysis/api/analysis-query.client.ts
@@ -69,7 +69,11 @@ const screenTimeQueryOptions = (dateQuery: GetScreenTimeQueryType) =>
     AnalysisScreenTimeData,
     ScreenTimeQueryKey
   >({
-    queryKey: ANALYSIS_KEYS.screenTime([dateQuery.period, dateQuery.date]),
+    queryKey: ANALYSIS_KEYS.screenTime([
+      dateQuery.period,
+      dateQuery.date,
+      dateQuery.timeZone,
+    ]),
     queryFn: async () => {
       const envelope = await analysisAPIService.getScreenTime(dateQuery);
       return envelope.data;

--- a/apps/web/src/features/analysis/api/analysis-query.server.ts
+++ b/apps/web/src/features/analysis/api/analysis-query.server.ts
@@ -45,7 +45,11 @@ export const serverScreenTimeQueryOptions = (
     AnalysisScreenTimeData,
     ScreenTimeQueryKey
   >({
-    queryKey: ANALYSIS_KEYS.screenTime([dateQuery.period, dateQuery.date]),
+    queryKey: ANALYSIS_KEYS.screenTime([
+      dateQuery.period,
+      dateQuery.date,
+      dateQuery.timeZone,
+    ]),
     queryFn: async () => {
       const envelope = await serverAnalysisAPIService.getScreenTime(dateQuery);
       return envelope.data;

--- a/apps/web/src/features/analysis/ui/ScreenTime.tsx
+++ b/apps/web/src/features/analysis/ui/ScreenTime.tsx
@@ -14,7 +14,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@recap/ui";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQueries } from "@tanstack/react-query";
 
 import { useTimeZone } from "@/entities/language";
 import { screenTimeQueryOptions } from "@/features/analysis/api/analysis-query.client";
@@ -34,14 +34,26 @@ const ScreenTime = ({ date }: { date: string }) => {
   const [mode, setMode] = useState<ScreenTimePeriodType>("DAILY");
   const timeZone = useTimeZone();
 
-  const { data } = useSuspenseQuery({
-    ...screenTimeQueryOptions({
-      date,
-      period: mode,
-      timeZone,
-    }),
-    select: (screenTimeData) =>
-      toScreenTimeChartState({ data: screenTimeData, mode, date, t }),
+  const [{ data: daily }, { data: weekly }] = useSuspenseQueries({
+    queries: [
+      screenTimeQueryOptions({
+        date,
+        period: "DAILY",
+        timeZone,
+      }),
+      screenTimeQueryOptions({
+        date,
+        period: "WEEKLY",
+        timeZone,
+      }),
+    ],
+  });
+
+  const data = toScreenTimeChartState({
+    data: mode === "DAILY" ? daily : weekly,
+    mode,
+    date,
+    t,
   });
 
   const isEmpty = data?.duration && data.duration <= 0;

--- a/apps/web/src/pages/auth/ui/ExtensionAuthPage.tsx
+++ b/apps/web/src/pages/auth/ui/ExtensionAuthPage.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
-import { authUnTokenAPIService } from "@/entities/auth/api";
-import { clientTokenStore } from "@/entities/auth/model/client-token-store";
 import { useAuth } from "@/entities/auth/ui";
+import { useGoogleTokenLogin } from "@/entities/login/model/use-google-token-login";
 
 function buildRedirectPath(redirect: string | null, date: string | null) {
   const path = redirect && redirect.startsWith("/") ? redirect : "/analysis";
@@ -22,40 +21,36 @@ export default function ExtensionAuthPage() {
   const { refreshAuth, unLogin } = useAuth();
   const startedRef = useRef(false);
 
+  const redirect = searchParams?.get("redirect") ?? null;
+  const date = searchParams?.get("date") ?? null;
+  const oAuthToken = searchParams?.get("oAuthToken");
+
+  const onLoginSuccess = useCallback(async () => {
+    await refreshAuth();
+    router.replace(buildRedirectPath(redirect, date));
+  }, [date, redirect, refreshAuth, router]);
+
+  const { login } = useGoogleTokenLogin({ onLoginSuccess });
+
   useEffect(() => {
     if (startedRef.current) return;
     startedRef.current = true;
 
-    const code = searchParams?.get("code");
-    const redirect = searchParams?.get("redirect");
-    const date = searchParams?.get("date");
-
     void (async () => {
       try {
-        if (!code) {
+        if (!oAuthToken) {
           await unLogin();
           router.replace("/analysis");
           return;
         }
 
-        clientTokenStore.set({
-          accessToken: clientTokenStore.getAccess() ?? "",
-          refreshToken: code,
-        });
-
-        const tokens = await authUnTokenAPIService.refreshTokens({
-          refreshToken: code,
-        });
-
-        clientTokenStore.set(tokens);
-        await refreshAuth();
-        router.replace(buildRedirectPath(redirect ?? null, date ?? null));
+        await login(oAuthToken);
       } catch {
         await unLogin();
         router.replace("/analysis");
       }
     })();
-  }, [refreshAuth, router, searchParams, unLogin]);
+  }, [login, oAuthToken, router, unLogin]);
 
   return (
     <div className="flex min-h-[40vh] items-center justify-center px-4 text-center text-sm text-gray-500">

--- a/packages/react-query-config/src/index.ts
+++ b/packages/react-query-config/src/index.ts
@@ -6,6 +6,7 @@ export { dehydrateState } from "./ssr";
 export {
   useMutation,
   type UseMutationOptions,
+  useQueries,
   useQuery,
   useQueryClient,
   type UseQueryOptions,


### PR DESCRIPTION
## 작업 내용

- ScreenTime 모드(DAILY/WEEKLY) 전환 시 매번 새 query를 조회하며 로딩 placeholder가 노출되던 UX를 개선했습니다.
  - web: `useSuspenseQueries`로 모드별 데이터를 동시 로드
  - extension: `useQueries`로 모드별 데이터를 동시 로드
  - 초기 로드 시 두 모드 데이터를 미리 확보해 모드 변경 시 스켈레톤/로딩 없이 즉시 전환되도록 처리했습니다.
- extension → web 자동 로그인 구조를 개선했습니다.
  - refresh 재발급으로 토큰만 set하던 방식 대신, 로그인 버튼과 동일한 `useGoogleTokenLogin` 훅의 `login` 메서드를 직접 호출하도록 변경했습니다.
  - extension에서 Google OAuth 토큰을 전달하면 웹에서 기존 구글 로그인 모듈을 재사용해 동일 계정으로 자동 로그인됩니다.

## 작업 목적

- 분석 화면에서 스크린 타임 모드를 자주 전환할 때 로딩이 반복되어 체감 성능이 떨어지는 문제를 줄이기 위함입니다.
- extension에서 대시보드로 이동할 때 웹 로그인 UX/로직을 별도 우회하지 않고, 기존 로그인 훅을 그대로 사용해 계정 연동을 단순하고 일관되게 유지하기 위함입니다.

### 스크린샷 (선택)
