### PR TITLE
feat: 스크린 타임 시간 파싱 함수 초 단위 반환으로 변경  

### DIFF
--- a/packages/features/src/analysis/model/to-analysis-bar-chart-state.ts
+++ b/packages/features/src/analysis/model/to-analysis-bar-chart-state.ts
@@ -32,7 +32,7 @@ export const toDailyAnalysisBarChartState = (
     const startHour = i * 2;
     return {
       key: `today-${startHour}`,
-      label: String(startHour),
+      label: startHour === 0 ? "" : String(startHour),
       subLabel: t("screenTime.dailyTimeSlotSubLabel", {
         start: padNumber(startHour),
         end: padNumber(startHour + 2),

--- a/packages/features/src/analysis/model/to-screen-time-chart-state.ts
+++ b/packages/features/src/analysis/model/to-screen-time-chart-state.ts
@@ -5,7 +5,6 @@ import type {
   AnalysisBarChartTranslateFn,
 } from "./analysis-bar-chart.type";
 import {
-  secondsToMinute,
   toDailyAnalysisBarChartState,
   toWeeklyAnalysisBarChartState,
 } from "./to-analysis-bar-chart-state";
@@ -32,14 +31,15 @@ export const toScreenTimeChartState = ({
     return { chartData: [], duration: 0 };
   }
 
-  const totalMinutes = secondsToMinute(data.totalStayDuration);
   const chartData =
     mode === "DAILY"
       ? toDailyAnalysisBarChartState(data.screenTimes, t)
       : toWeeklyAnalysisBarChartState(data.screenTimes, date, t);
 
   const duration =
-    mode === "DAILY" ? totalMinutes * 60 : Math.round(totalMinutes / 7) * 60;
+    mode === "DAILY"
+      ? data.totalStayDuration
+      : Math.round(data.totalStayDuration / 7);
 
   return { chartData, duration };
 };

--- a/packages/lib/src/dayjs/duration-formatter.ts
+++ b/packages/lib/src/dayjs/duration-formatter.ts
@@ -9,6 +9,11 @@ export const formatDuration = (seconds: number, t: TranslateFn): string => {
   }
 
   const totalSeconds = Math.floor(seconds);
+
+  if (totalSeconds < 60) {
+    return t("common:duration.second", { count: totalSeconds });
+  }
+
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const secs = totalSeconds % 60;


### PR DESCRIPTION
## 작업 내용

- 스크린타임 duration 가공을 분 단위 변환 없이 API의 초(`totalStayDuration`)를 그대로 사용하도록 변경
- `formatDuration`에서 60초 미만일 때 초 단위로 표시되도록 처리
- Daily 차트에서 0시 라벨(`0`)이 노출되지 않도록 empty 라벨 조건 추가

## 작업 목적

- 기존 분 단위 변환 과정에서 1분 미만 사용 시간이 0으로 보이거나 정확도가 떨어지는 문제를 해결하기 위함
- 초 단위 기준으로 duration을 파싱·표시해 실제 사용 시간을 더 정확하게 반영하기 위함

### 스크린샷 (선택)