### PR TITLE
refactor: 익스텐션 auth 토큰 갱신 로직 packages/api 공통 서비스 적용

### DIFF
--- a/apps/extension/src/app/providers/query-provider/QueryProvider.tsx
+++ b/apps/extension/src/app/providers/query-provider/QueryProvider.tsx
@@ -1,8 +1,27 @@
 import type { PropsWithChildren } from "react";
+import { APIError } from "@recap/api";
 import { ReactQueryProvider } from "@recap/react-query";
 
+import { useAuth } from "@/entities/auth/ui";
+
 const QueryProvider = ({ children }: PropsWithChildren) => {
-  return <ReactQueryProvider>{children}</ReactQueryProvider>;
+  const { logout } = useAuth();
+
+  return (
+    <ReactQueryProvider
+      options={{
+        onError: (error: unknown) => {
+          if (!(error instanceof APIError)) return;
+
+          if (error.code === "REFRESH_TOKEN_NOT_FOUND") {
+            logout();
+          }
+        },
+      }}
+    >
+      {children}
+    </ReactQueryProvider>
+  );
 };
 
 export default QueryProvider;

--- a/apps/extension/src/shared/lib/create-authed-rest.ts
+++ b/apps/extension/src/shared/lib/create-authed-rest.ts
@@ -1,5 +1,11 @@
 import type { RestAPIProtocol } from "@recap/api";
-import { RestAPI, RestAPIInstance } from "@recap/api";
+import {
+  APIError,
+  AuthUnTokenAPIService,
+  generateRestAPI,
+  RestAPI,
+  RestAPIInstance,
+} from "@recap/api";
 
 import { tokenStore } from "@/shared/lib/token-store";
 
@@ -7,52 +13,55 @@ type RefreshResponse = { accessToken: string; refreshToken: string };
 
 let refreshPromise: Promise<RefreshResponse> | null = null;
 
-function buildApiUrl(baseURL: string, apiBaseURL: string, path: string) {
-  const normalizedPath = path.replace(/^\/+/, "");
-  const prefix = apiBaseURL ? `/${apiBaseURL}` : "";
-  return `${baseURL}${prefix}/${normalizedPath}`;
+function isRefreshUrl(url: string) {
+  return url.includes("/auth/refresh");
 }
 
 type CreateAuthedRestAPIOptions = {
   apiBaseURL?: string;
 };
 
-async function refreshTokens(
-  baseURL: string,
-  apiBaseURL: string,
-): Promise<RefreshResponse> {
-  const refreshToken = await tokenStore.getRefresh();
-  if (!refreshToken) throw new Error("No refresh token");
-
-  const res = await fetch(buildApiUrl(baseURL, apiBaseURL, "auth/refresh"), {
-    method: "POST",
-    headers: { "Content-Type": "application/json", Accept: "application/json" },
-    body: JSON.stringify({ refreshToken }),
-  });
-
-  if (!res.ok) {
-    throw new Error("Refresh failed");
-  }
-
-  return (await res.json()) as RefreshResponse;
-}
-
-function isRefreshUrl(url: string) {
-  return url.includes("/auth/refresh");
-}
-
 export function createAuthedRestAPI(
   baseURL: string,
   options?: CreateAuthedRestAPIOptions,
 ): RestAPIProtocol {
   const apiBaseURL = options?.apiBaseURL ?? "v1";
+
+  const authUnTokenAPIService = new AuthUnTokenAPIService(
+    generateRestAPI(
+      { APIbaseURL: apiBaseURL },
+      {
+        baseURL,
+        withCredentials: false,
+        headers: { Accept: "application/json" },
+      },
+    ),
+  );
+
+  async function refreshTokens(): Promise<RefreshResponse> {
+    const refreshToken = await tokenStore.getRefresh();
+    if (!refreshToken) {
+      throw new APIError("Refresh token not found", {
+        code: "REFRESH_TOKEN_NOT_FOUND",
+        status: 401,
+      });
+    }
+
+    const refreshRes = await authUnTokenAPIService.refreshTokens({
+      refreshToken,
+    });
+
+    await tokenStore.set(refreshRes);
+
+    return refreshRes;
+  }
+
   const instance = new RestAPIInstance(baseURL, {
     withCredentials: false,
     headers: { Accept: "application/json" },
 
     onRequest: async ({ url, init }) => {
       const accessToken = await tokenStore.getAccess();
-
       if (!accessToken) return { url, init };
 
       const headers = new Headers(init.headers);
@@ -65,30 +74,26 @@ export function createAuthedRestAPI(
       if (res.status !== 401) return res;
       if (isRefreshUrl(url)) return res;
 
+      // 동시에 여러 요청이 401을 받아도 refresh는 한 번만 수행한다.
       if (!refreshPromise) {
-        refreshPromise = (async () => {
-          try {
-            const tokens = await refreshTokens(baseURL, apiBaseURL);
-            await tokenStore.set(tokens);
-            return tokens;
-          } finally {
-            refreshPromise = null;
-          }
-        })();
+        refreshPromise = refreshTokens().finally(() => {
+          refreshPromise = null;
+        });
       }
 
       try {
-        await refreshPromise;
-
-        const newAccess = await tokenStore.getAccess();
-        if (!newAccess) return res;
+        const refreshRes = await refreshPromise;
 
         const retryHeaders = new Headers(init.headers);
-        retryHeaders.set("Authorization", `Bearer ${newAccess}`);
+        retryHeaders.set("Authorization", `Bearer ${refreshRes.accessToken}`);
+        retryHeaders.set("Accept", "application/json");
 
         return fetch(url, { ...init, headers: retryHeaders });
-      } catch {
-        await tokenStore.clear();
+      } catch (error) {
+        if (error instanceof APIError) {
+          throw error;
+        }
+
         return res;
       }
     },


### PR DESCRIPTION
## 작업 내용

- `apps/extension/src/shared/lib/create-authed-rest.ts` 리팩토링
  - raw `fetch`로 직접 호출하던 토큰 refresh 로직을 `packages/api`의 공통 서비스(`AuthUnTokenAPIService` + `generateRestAPI`)로 교체
  - 이를 통해 refresh 응답의 envelope(`{ success, data }`) 언랩과 zod 스키마 검증이 web과 동일하게 적용됨
  - refresh token이 없을 때 `REFRESH_TOKEN_NOT_FOUND` 코드의 `APIError`를 throw하도록 변경 (기존에는 에러를 삼키고 원본 401 응답만 반환)
  - refresh 실패 시 토큰 clear 후 `AUTH_CHANGED` 메시지를 브로드캐스트하여 background에서 세션이 만료된 경우에도 사이드패널 UI가 로그아웃 상태로 갱신되도록 처리
  - 동시 다발 401 발생 시 refresh 요청이 한 번만 수행되도록 `refreshPromise` dedupe 유지
- `apps/extension/src/app/providers/query-provider/QueryProvider.tsx` 변경
  - web의 `ReactQueryProvider`와 동일하게 react-query 전역 `onError`에서 `APIError`의 `code === "REFRESH_TOKEN_NOT_FOUND"`인 경우 `logout()` 호출

## 작업 목적

- extension에서 refresh token이 401을 받는 경우가 처리되지 않는 문제 수정
  - 기존 raw `fetch` 기반 refresh는 응답 envelope을 벗기지 않아 `accessToken`/`refreshToken`이 `undefined`로 저장 시도됨 → 토큰이 갱신되지 않고, rotation된 refresh token이 폐기되어 이후 모든 refresh가 401로 실패
  - refresh 실패 에러가 삼켜져 호출부와 UI가 세션 만료를 인지할 수 없었음
- web과 extension의 auth 처리 경로(토큰 갱신 → 실패 시 에러 코드 throw → 전역 onError에서 로그아웃)를 동일한 구조로 통일

### 스크린샷 (선택)
