### PR TITLE
feat: 웹 로그인 초기 진입 시 툴팁 새로고침 안내 기능 구현 

### DIFF
--- a/apps/web/src/entities/auth/api/auth-session-client.ts
+++ b/apps/web/src/entities/auth/api/auth-session-client.ts
@@ -1,4 +1,5 @@
 import { clientTokenStore } from "@/entities/auth/model/client-token-store";
+import { removeInitialized } from "@/shared/lib/local-storage";
 
 type LoginPayload = {
   oAuthToken: string;
@@ -68,12 +69,14 @@ export async function logoutSession() {
   }
 
   clientTokenStore.clear();
+  removeInitialized();
 
   return res.json();
 }
 
 export async function clearSession() {
   clientTokenStore.clear();
+  removeInitialized();
 
   await fetch("/api/auth/logout", {
     method: "POST",

--- a/apps/web/src/shared/lib/local-storage-key.ts
+++ b/apps/web/src/shared/lib/local-storage-key.ts
@@ -1,0 +1,6 @@
+export const LocalStorageKey = {
+  IsInitialized: "isInitialized",
+} as const;
+
+export type LocalStorageKey =
+  (typeof LocalStorageKey)[keyof typeof LocalStorageKey];

--- a/apps/web/src/shared/lib/local-storage.ts
+++ b/apps/web/src/shared/lib/local-storage.ts
@@ -1,0 +1,48 @@
+import { LocalStorageKey } from "./local-storage-key";
+
+const canUseLocalStorage = () => typeof window !== "undefined";
+
+const setItem = <T>(key: LocalStorageKey, items: T): void => {
+  if (!canUseLocalStorage()) return;
+
+  try {
+    window.localStorage.setItem(key, JSON.stringify(items));
+  } catch (error) {
+    console.log("localstorage error: ", error);
+  }
+};
+
+const getItemOrNull = <T>(key: LocalStorageKey): T | null => {
+  if (!canUseLocalStorage()) return null;
+
+  try {
+    const data = window.localStorage.getItem(key);
+    return data ? (JSON.parse(data) as T) : null;
+  } catch (error) {
+    console.log("localstorage error: ", error);
+    return null;
+  }
+};
+
+const removeItem = (key: LocalStorageKey): void => {
+  if (!canUseLocalStorage()) return;
+
+  try {
+    window.localStorage.removeItem(key);
+  } catch (error) {
+    console.log("localstorage error: ", error);
+  }
+};
+
+/** 새로고침 툴팁 첫 노출 여부 */
+export const getInitialized = (): boolean => {
+  return !!getItemOrNull<boolean>(LocalStorageKey.IsInitialized);
+};
+
+export const setInitialized = (value: boolean): void => {
+  setItem<boolean>(LocalStorageKey.IsInitialized, value);
+};
+
+export const removeInitialized = (): void => {
+  removeItem(LocalStorageKey.IsInitialized);
+};

--- a/apps/web/src/shared/ui/ScreenTimeWeeklyBarChart.tsx
+++ b/apps/web/src/shared/ui/ScreenTimeWeeklyBarChart.tsx
@@ -27,6 +27,7 @@ const ScreenTimeWeeklyBarChart = ({
       tooltipContentClassName={cn(
         "rounded-xl bg-white px-4 py-3 text-sm text-gray-900 shadow-lg ring-1 ring-black/10",
       )}
+      tooltipArrowClassName={cn("fill-white")}
     />
   );
 };

--- a/apps/web/src/widgets/layout/model/use-refresh-tooltip.ts
+++ b/apps/web/src/widgets/layout/model/use-refresh-tooltip.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { useDelayedOpen } from "@recap/lib";
+
+import { useAuth } from "@/entities/auth/ui";
+import { getInitialized, setInitialized } from "@/shared/lib/local-storage";
+
+const DEFAULT_DURATION_MS = 2000;
+
+type UseRefreshTooltipOptions = {
+  duration?: number;
+};
+
+/**
+ * 로그인 후에만 첫 1회 refresh tooltip을 delay 동안 노출.
+ * - UI delay: `useDelayedOpen`
+ * - 노출 여부: `getInitialized` / `setInitialized`
+ * - 로그아웃 clear: `logoutSession` / `clearSession`의 `removeInitialized`
+ */
+export const useRefreshTooltip = (options: UseRefreshTooltipOptions = {}) => {
+  const { duration = DEFAULT_DURATION_MS } = options;
+  const { isReady, isLoggedIn } = useAuth();
+
+  const handleAutoClose = useCallback(() => {
+    setInitialized(true);
+  }, []);
+
+  const { open, start, close } = useDelayedOpen({
+    duration,
+    onAutoClose: handleAutoClose,
+  });
+
+  useEffect(() => {
+    if (!isReady || !isLoggedIn) {
+      close();
+      return;
+    }
+
+    if (getInitialized()) return;
+
+    start();
+
+    return () => {
+      close();
+    };
+  }, [isReady, isLoggedIn, start, close]);
+
+  return { open };
+};

--- a/apps/web/src/widgets/layout/ui/RefreshButton.tsx
+++ b/apps/web/src/widgets/layout/ui/RefreshButton.tsx
@@ -16,6 +16,7 @@ import AutoRenewIcon from "@/shared/assets/icons/auto-renew.svg";
 import { NAVIGATION_TAB } from "@/shared/config";
 import { RoundButton } from "@/shared/ui";
 import { useGnbRoute } from "@/widgets/layout/model/use-gnb-route";
+import { useRefreshTooltip } from "@/widgets/layout/model/use-refresh-tooltip";
 
 const QUERY_KEY_BY_TAB = {
   [NAVIGATION_TAB.AI_RECAP]: AI_RECAP_KEYS.all,
@@ -26,6 +27,7 @@ const RefreshButton = () => {
   const { tab } = useGnbRoute();
   const { t } = useLocale("landing");
   const queryClient = useQueryClient();
+  const { open } = useRefreshTooltip({ duration: 4000 });
 
   const handleRefresh = () => {
     const queryKey = QUERY_KEY_BY_TAB[tab as keyof typeof QUERY_KEY_BY_TAB];
@@ -37,7 +39,7 @@ const RefreshButton = () => {
 
   return (
     <TooltipProvider>
-      <Tooltip>
+      <Tooltip open={open}>
         <TooltipTrigger asChild>
           <RoundButton
             className="group"

--- a/apps/web/src/widgets/layout/ui/RefreshButton.tsx
+++ b/apps/web/src/widgets/layout/ui/RefreshButton.tsx
@@ -1,6 +1,13 @@
 "use client";
 
 import { useLocale } from "@recap/i18n";
+import {
+  Tooltip,
+  TooltipArrow,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@recap/ui";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { AI_RECAP_KEYS } from "@/features/ai-recap/api/query-keys";
@@ -29,16 +36,30 @@ const RefreshButton = () => {
   };
 
   return (
-    <RoundButton
-      className="group"
-      aria-haspopup="dialog"
-      onClick={handleRefresh}
-    >
-      <div className="flex items-center gap-1 py-1.5 pr-1 pl-2.5">
-        <AutoRenewIcon />
-        <p className="text-subtitle-2-rg text-gray-900">{t("refresh")}</p>
-      </div>
-    </RoundButton>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <RoundButton
+            className="group"
+            aria-label={t("refresh")}
+            onClick={handleRefresh}
+          >
+            <div className="flex items-center gap-1 py-1.5 pr-1 pl-2.5">
+              <AutoRenewIcon />
+              <p className="text-subtitle-2-rg text-gray-900">{t("refresh")}</p>
+            </div>
+          </RoundButton>
+        </TooltipTrigger>
+        <TooltipContent
+          side="bottom"
+          sideOffset={4}
+          className="text-body-2 rounded-xl bg-gray-900 px-3 py-2 text-white shadow-none ring-0"
+        >
+          {t("refreshTooltip")}
+          <TooltipArrow className="fill-gray-900" width={21} height={10} />
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 };
 

--- a/packages/i18n/src/locales/en/landing.json
+++ b/packages/i18n/src/locales/en/landing.json
@@ -20,6 +20,7 @@
     "placeholder": "Select date"
   },
   "refresh": "Refresh",
+  "refreshTooltip": "Click refresh to update the data.",
   "sendFeedback": "Send feedback",
   "feedback": {
     "contentLabel": "Message",

--- a/packages/i18n/src/locales/ja/landing.json
+++ b/packages/i18n/src/locales/ja/landing.json
@@ -20,6 +20,7 @@
     "placeholder": "日付を選択"
   },
   "refresh": "更新",
+  "refreshTooltip": "更新を押してデータを更新してください。",
   "sendFeedback": "ご意見を送る",
   "feedback": {
     "contentLabel": "お問い合わせ内容",

--- a/packages/i18n/src/locales/ko/landing.json
+++ b/packages/i18n/src/locales/ko/landing.json
@@ -20,6 +20,7 @@
     "placeholder": "날짜 선택"
   },
   "refresh": "새로고침",
+  "refreshTooltip": "새로고침을 눌러서 데이터를 업데이트 하세요.",
   "sendFeedback": "의견 보내기",
   "feedback": {
     "contentLabel": "문의 내용",

--- a/packages/lib/src/hooks/index.ts
+++ b/packages/lib/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from "./use-boolean";
+export * from "./use-delayed-open";
 export * from "./use-disclosure";
 export * from "./use-uncontrolled";
 export * from "./use-update-effect";

--- a/packages/lib/src/hooks/use-delayed-open.ts
+++ b/packages/lib/src/hooks/use-delayed-open.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+import { useDisclosure } from "./use-disclosure";
+
+export type UseDelayedOpenOptions = {
+  /** 열린 뒤 자동으로 닫히기까지 시간(ms) */
+  duration?: number;
+  /** duration이 끝나 자동으로 닫힐 때 */
+  onAutoClose?: () => void;
+};
+
+export type UseDelayedOpenReturn = {
+  open: boolean;
+  /** 열고 `duration` 후 자동 close */
+  start: () => void;
+  close: () => void;
+};
+
+const DEFAULT_DURATION_MS = 2000;
+
+/**
+ * `start()` 호출 시 열고, `duration` 동안만 유지한 뒤 닫는다.
+ * localStorage / auth 와 무관한 순수 지연 제어 훅.
+ */
+const useDelayedOpen = (
+  options: UseDelayedOpenOptions = {},
+): UseDelayedOpenReturn => {
+  const { duration = DEFAULT_DURATION_MS, onAutoClose } = options;
+  const [open, { open: show, close }] = useDisclosure(false);
+  const timerRef = useRef<number | null>(null);
+  const onAutoCloseRef = useRef(onAutoClose);
+  onAutoCloseRef.current = onAutoClose;
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current == null) return;
+    window.clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+
+  const start = useCallback(() => {
+    clearTimer();
+    show();
+    timerRef.current = window.setTimeout(() => {
+      close();
+      timerRef.current = null;
+      onAutoCloseRef.current?.();
+    }, duration);
+  }, [clearTimer, show, close, duration]);
+
+  const closeAndClear = useCallback(() => {
+    clearTimer();
+    close();
+  }, [clearTimer, close]);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  return {
+    open,
+    start,
+    close: closeAndClear,
+  };
+};
+
+export { useDelayedOpen };


### PR DESCRIPTION
## 작업 내용

- Radix UI 기반 새로고침 안내 툴팁을 적용했습니다.
- 로그인 후 최초 1회 동안만 툴팁이 노출되도록 구현했습니다.
- 툴팁 노출 시간을 제어하는 `useDelayedOpen` 공통 훅을 추가했습니다.
- localStorage 유틸리티로 툴팁 초기화 상태를 관리하고, 로그아웃 시 해당 상태를 제거합니다.
- 툴팁 안내 문구를 한국어, 영어, 일본어로 추가했습니다.

## 작업 목적

- 로그인한 사용자가 새로고침 버튼으로 데이터를 갱신할 수 있음을 안내합니다.
- 최초 안내 이후에는 툴팁이 반복 노출되지 않도록 사용자 경험을 개선합니다.
- 지연 노출 UI 로직과 저장소 및 인증 상태 로직을 분리해 재사용성과 유지보수성을 높입니다.

### 스크린샷 (선택)

- 첨부 예정
