### PR TITLE
feat: 익스텐션 로그인 초기 진입 시 툴팁 새로고침 안내 기능 구현

### DIFF
--- a/apps/extension/src/entities/auth/ui/AuthProvider.tsx
+++ b/apps/extension/src/entities/auth/ui/AuthProvider.tsx
@@ -8,6 +8,7 @@ import {
 
 import { MESSAGE_TYPE } from "@/entities/history/model/messages.type";
 import useBrowserMessage from "@/shared/lib/browser/use-browser-message";
+import { removeInitialized } from "@/shared/lib/local-storage";
 import { tokenStore } from "@/shared/lib/token-store";
 
 import { AuthContext, type AuthValue } from "./auth-context";
@@ -33,6 +34,7 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
 
   const logout = useCallback(() => {
     void tokenStore.clear();
+    removeInitialized();
     setIsLoggedIn(false);
   }, []);
 

--- a/apps/extension/src/shared/lib/local-storage-key.ts
+++ b/apps/extension/src/shared/lib/local-storage-key.ts
@@ -1,0 +1,6 @@
+export const LocalStorageKey = {
+  IsInitialized: "isInitialized",
+} as const;
+
+export type LocalStorageKey =
+  (typeof LocalStorageKey)[keyof typeof LocalStorageKey];

--- a/apps/extension/src/shared/lib/local-storage.ts
+++ b/apps/extension/src/shared/lib/local-storage.ts
@@ -1,0 +1,48 @@
+import { LocalStorageKey } from "./local-storage-key";
+
+const canUseLocalStorage = () => typeof window !== "undefined";
+
+const setItem = <T>(key: LocalStorageKey, items: T): void => {
+  if (!canUseLocalStorage()) return;
+
+  try {
+    window.localStorage.setItem(key, JSON.stringify(items));
+  } catch (error) {
+    console.log("localstorage error: ", error);
+  }
+};
+
+const getItemOrNull = <T>(key: LocalStorageKey): T | null => {
+  if (!canUseLocalStorage()) return null;
+
+  try {
+    const data = window.localStorage.getItem(key);
+    return data ? (JSON.parse(data) as T) : null;
+  } catch (error) {
+    console.log("localstorage error: ", error);
+    return null;
+  }
+};
+
+const removeItem = (key: LocalStorageKey): void => {
+  if (!canUseLocalStorage()) return;
+
+  try {
+    window.localStorage.removeItem(key);
+  } catch (error) {
+    console.log("localstorage error: ", error);
+  }
+};
+
+/** 새로고침 툴팁 첫 노출 여부 */
+export const getInitialized = (): boolean => {
+  return !!getItemOrNull<boolean>(LocalStorageKey.IsInitialized);
+};
+
+export const setInitialized = (value: boolean): void => {
+  setItem<boolean>(LocalStorageKey.IsInitialized, value);
+};
+
+export const removeInitialized = (): void => {
+  removeItem(LocalStorageKey.IsInitialized);
+};

--- a/apps/extension/src/shared/ui/ScreenTimeWeeklyBarChart.tsx
+++ b/apps/extension/src/shared/ui/ScreenTimeWeeklyBarChart.tsx
@@ -26,6 +26,7 @@ const ScreenTimeWeeklyBarChart = ({
       tooltipContentClassName={cn(
         "rounded-xl bg-white px-4 py-3 text-sm text-gray-900 shadow-lg ring-1 ring-black/10",
       )}
+      tooltipArrowClassName={cn("fill-white")}
     />
   );
 };

--- a/apps/extension/src/widgets/layout/model/use-refresh-tooltip.ts
+++ b/apps/extension/src/widgets/layout/model/use-refresh-tooltip.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect } from "react";
+import { useDelayedOpen } from "@recap/lib";
+
+import { useAuth } from "@/entities/auth/ui";
+import { getInitialized, setInitialized } from "@/shared/lib/local-storage";
+
+const DEFAULT_DURATION_MS = 2000;
+
+type UseRefreshTooltipOptions = {
+  duration?: number;
+};
+
+/**
+ * 로그인 후에만 첫 1회 refresh tooltip을 delay 동안 노출.
+ * - UI delay: `useDelayedOpen`
+ * - 노출 여부: `getInitialized` / `setInitialized`
+ * - 로그아웃 clear: `AuthProvider.logout`의 `removeInitialized`
+ */
+export const useRefreshTooltip = (options: UseRefreshTooltipOptions = {}) => {
+  const { duration = DEFAULT_DURATION_MS } = options;
+  const { isReady, isLoggedIn } = useAuth();
+
+  const handleAutoClose = useCallback(() => {
+    setInitialized(true);
+  }, []);
+
+  const { open, start, close } = useDelayedOpen({
+    duration,
+    onAutoClose: handleAutoClose,
+  });
+
+  useEffect(() => {
+    if (!isReady || !isLoggedIn) {
+      close();
+      return;
+    }
+
+    if (getInitialized()) return;
+
+    start();
+
+    return () => {
+      close();
+    };
+  }, [isReady, isLoggedIn, start, close]);
+
+  return { open };
+};

--- a/apps/extension/src/widgets/layout/ui/RefreshButton.tsx
+++ b/apps/extension/src/widgets/layout/ui/RefreshButton.tsx
@@ -1,10 +1,18 @@
 import { useLocale } from "@recap/i18n";
 import { useQueryClient } from "@recap/react-query";
+import {
+  Tooltip,
+  TooltipArrow,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@recap/ui";
 
 import { AI_RECAP_KEYS } from "@/features/ai-recap/api/query-keys";
 import { ANALYSIS_KEYS } from "@/features/analysis/api/query-keys";
 import RefreshSvg from "@/shared/assets/icons/refresh.svg?react";
 import { NAVIGATION_TAB } from "@/shared/config";
+import { useRefreshTooltip } from "@/widgets/layout/model/use-refresh-tooltip";
 import { useTabNavigationStore } from "@/widgets/tab-navigation/model";
 
 const QUERY_KEY_BY_TAB = {
@@ -16,6 +24,7 @@ const RefreshButton = () => {
   const { t } = useLocale("landing");
   const activeTab = useTabNavigationStore((state) => state.activeTab);
   const queryClient = useQueryClient();
+  const { open } = useRefreshTooltip({ duration: 4000 });
 
   const handleRefresh = () => {
     const queryKey =
@@ -27,14 +36,28 @@ const RefreshButton = () => {
   };
 
   return (
-    <button
-      type="button"
-      className="absolute inset-y-0 left-0 flex items-center justify-center px-2.5 cursor-pointer border-r border-gray-200"
-      aria-label={t("refresh")}
-      onClick={handleRefresh}
-    >
-      <RefreshSvg />
-    </button>
+    <TooltipProvider>
+      <Tooltip open={open}>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="absolute inset-y-0 left-0 flex cursor-pointer items-center justify-center border-r border-gray-200 px-2.5"
+            aria-label={t("refresh")}
+            onClick={handleRefresh}
+          >
+            <RefreshSvg />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent
+          side="bottom"
+          sideOffset={0}
+          className="text-body-2 rounded-xl bg-gray-900 px-3 py-2 text-white shadow-none ring-0"
+        >
+          {t("refreshTooltip")}
+          <TooltipArrow className="fill-gray-900" width={21} height={10} />
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 };
 


### PR DESCRIPTION
## 작업 내용

- Extension 로그인 후 새로고침 버튼 하단에 안내 툴팁이 4초간 노출되도록 구현했습니다.
- Local Storage에 툴팁 노출 여부를 저장해 로그인 상태에서 최초 1회만 표시되도록 처리했습니다.
- 로그아웃 시 노출 상태를 초기화해 다음 로그인에서 툴팁이 다시 표시되도록 했습니다.
- 주간 스크린 타임 차트 툴팁 화살표 색상을 배경색과 동일하게 맞췄습니다.

## 작업 목적

- Extension 로그인 직후 사용자가 데이터 갱신 기능을 쉽게 발견하고 사용할 수 있도록 안내합니다.
- 이미 안내를 확인한 사용자에게 툴팁이 반복 노출되지 않도록 해 불필요한 UI 방해를 줄입니다.

### 스크린샷 (선택)

<!-- 필요 시 새로고침 안내 툴팁 스크린샷을 첨부해 주세요. -->