### PR TITLE
fix: 로그아웃 후 새로고침 안내 툴팁 재노출 방지

### DIFF
--- a/apps/extension/src/entities/auth/ui/AuthProvider.tsx
+++ b/apps/extension/src/entities/auth/ui/AuthProvider.tsx
@@ -8,7 +8,6 @@ import {
 
 import { MESSAGE_TYPE } from "@/entities/history/model/messages.type";
 import useBrowserMessage from "@/shared/lib/browser/use-browser-message";
-import { removeInitialized } from "@/shared/lib/local-storage";
 import { tokenStore } from "@/shared/lib/token-store";
 
 import { AuthContext, type AuthValue } from "./auth-context";
@@ -34,7 +33,6 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
 
   const logout = useCallback(() => {
     void tokenStore.clear();
-    removeInitialized();
     setIsLoggedIn(false);
   }, []);
 

--- a/apps/extension/src/shared/lib/local-storage.ts
+++ b/apps/extension/src/shared/lib/local-storage.ts
@@ -24,16 +24,6 @@ const getItemOrNull = <T>(key: LocalStorageKey): T | null => {
   }
 };
 
-const removeItem = (key: LocalStorageKey): void => {
-  if (!canUseLocalStorage()) return;
-
-  try {
-    window.localStorage.removeItem(key);
-  } catch (error) {
-    console.log("localstorage error: ", error);
-  }
-};
-
 /** 새로고침 툴팁 첫 노출 여부 */
 export const getInitialized = (): boolean => {
   return !!getItemOrNull<boolean>(LocalStorageKey.IsInitialized);
@@ -41,8 +31,4 @@ export const getInitialized = (): boolean => {
 
 export const setInitialized = (value: boolean): void => {
   setItem<boolean>(LocalStorageKey.IsInitialized, value);
-};
-
-export const removeInitialized = (): void => {
-  removeItem(LocalStorageKey.IsInitialized);
 };

--- a/apps/extension/src/widgets/layout/model/use-refresh-tooltip.ts
+++ b/apps/extension/src/widgets/layout/model/use-refresh-tooltip.ts
@@ -14,7 +14,6 @@ type UseRefreshTooltipOptions = {
  * 로그인 후에만 첫 1회 refresh tooltip을 delay 동안 노출.
  * - UI delay: `useDelayedOpen`
  * - 노출 여부: `getInitialized` / `setInitialized`
- * - 로그아웃 clear: `AuthProvider.logout`의 `removeInitialized`
  */
 export const useRefreshTooltip = (options: UseRefreshTooltipOptions = {}) => {
   const { duration = DEFAULT_DURATION_MS } = options;

--- a/apps/web/src/entities/auth/api/auth-session-client.ts
+++ b/apps/web/src/entities/auth/api/auth-session-client.ts
@@ -1,5 +1,4 @@
 import { clientTokenStore } from "@/entities/auth/model/client-token-store";
-import { removeInitialized } from "@/shared/lib/local-storage";
 
 type LoginPayload = {
   oAuthToken: string;
@@ -69,14 +68,12 @@ export async function logoutSession() {
   }
 
   clientTokenStore.clear();
-  removeInitialized();
 
   return res.json();
 }
 
 export async function clearSession() {
   clientTokenStore.clear();
-  removeInitialized();
 
   await fetch("/api/auth/logout", {
     method: "POST",

--- a/apps/web/src/shared/lib/local-storage.ts
+++ b/apps/web/src/shared/lib/local-storage.ts
@@ -24,6 +24,7 @@ const getItemOrNull = <T>(key: LocalStorageKey): T | null => {
   }
 };
 
+// eslint-disable-next-line unused-imports/no-unused-vars
 const removeItem = (key: LocalStorageKey): void => {
   if (!canUseLocalStorage()) return;
 
@@ -41,8 +42,4 @@ export const getInitialized = (): boolean => {
 
 export const setInitialized = (value: boolean): void => {
   setItem<boolean>(LocalStorageKey.IsInitialized, value);
-};
-
-export const removeInitialized = (): void => {
-  removeItem(LocalStorageKey.IsInitialized);
 };

--- a/apps/web/src/widgets/layout/model/use-refresh-tooltip.ts
+++ b/apps/web/src/widgets/layout/model/use-refresh-tooltip.ts
@@ -16,7 +16,6 @@ type UseRefreshTooltipOptions = {
  * 로그인 후에만 첫 1회 refresh tooltip을 delay 동안 노출.
  * - UI delay: `useDelayedOpen`
  * - 노출 여부: `getInitialized` / `setInitialized`
- * - 로그아웃 clear: `logoutSession` / `clearSession`의 `removeInitialized`
  */
 export const useRefreshTooltip = (options: UseRefreshTooltipOptions = {}) => {
   const { duration = DEFAULT_DURATION_MS } = options;


### PR DESCRIPTION
## 작업 내용

- Web과 Extension에서 로그아웃할 때 새로고침 안내 툴팁의 최초 노출 상태를 초기화하던 로직을 제거했습니다.
- 더 이상 사용하지 않는 `removeInitialized`와 Local Storage 삭제 유틸을 정리했습니다.
- 툴팁 훅의 로그아웃 초기화 관련 주석을 현재 동작에 맞게 수정했습니다.

## 작업 목적

- 사용자가 새로고침 안내 툴팁을 한 번 확인했다면 로그아웃 후 다시 로그인해도 반복 노출되지 않도록 합니다.
- Web과 Extension에서 툴팁 최초 노출 정책을 동일하게 유지합니다.

### 스크린샷 (선택)

<!-- 필요 시 로그아웃 및 재로그인 후 툴팁 동작 화면을 첨부해 주세요. -->