### PR TITLE
qa: 사용자 프로필 기반 Timezone SSR 동기화 및 말줄임 오류 수정

### DIFF
--- a/apps/extension/src/features/analysis/ui/CategoryLink.tsx
+++ b/apps/extension/src/features/analysis/ui/CategoryLink.tsx
@@ -11,7 +11,7 @@ const CategoryLink = ({
 
   return (
     <div className="bg-gray-75 flex items-center justify-between rounded-full pl-2 pr-4 py-2">
-      <div className="flex items-center gap-3">
+      <div className="flex min-w-0 items-center gap-3">
         {faviconUrl ? (
           <img
             src={faviconUrl}
@@ -21,10 +21,10 @@ const CategoryLink = ({
         ) : (
           <div className="size-6 rounded-full bg-gray-300" />
         )}
-        <p className="text-body-1 text-gray-500">{domain}</p>
+        <p className="text-body-1 max-w-44 truncate text-gray-500">{domain}</p>
       </div>
 
-      <p className="text-body-1 text-gray-900">
+      <p className="text-body-1 ml-2 max-w-19.25 shrink-0 truncate text-gray-900">
         {formatDuration(stayDuration, t)}
       </p>
     </div>

--- a/apps/web/app/analysis/page.tsx
+++ b/apps/web/app/analysis/page.tsx
@@ -1,9 +1,11 @@
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { SERVER_TIMEZONE } from "@recap/lib";
+import { createQueryClient, dehydrateState } from "@recap/react-query";
 import { Grid, Stack } from "@recap/ui";
+import { HydrationBoundary } from "@tanstack/react-query";
 
 import AuthBoundary from "@/entities/auth/ui/AuthBoundary";
+import { TimeZoneProvider } from "@/entities/language";
 import {
   serverCategoryAnalysisQueryOptions,
   serverFrequentlyVisitedSitesQueryOptions,
@@ -23,6 +25,7 @@ import TopVisitedSitesSkeleton from "@/features/analysis/ui/TopVisitedSitesSkele
 import TrackDomainSetting from "@/features/analysis/ui/TrackDomainSetting";
 import WorkPattern from "@/features/analysis/ui/WorkPattern";
 import WorkPatternSkeleton from "@/features/analysis/ui/WorkPatternSkeleton";
+import { getServerUserTimeZone } from "@/features/settings/api/user-query.server";
 import AnalysisLoadingPage from "@/pages/analysis/ui/AnalysisLoadingPage";
 import AnalysisUnloginPage from "@/pages/analysis/ui/AnalysisUnloginPage";
 import { getSafeQueryDate } from "@/shared/lib/date/safe-query-date";
@@ -40,89 +43,100 @@ export default async function Page({ searchParams }: AnalysisRouteProps) {
 
   const date = getSafeQueryDate(dateParam);
 
+  const queryClient = createQueryClient();
+  const timeZone = await getServerUserTimeZone(queryClient);
+
+  if (!timeZone) {
+    return <AnalysisUnloginPage />;
+  }
+
   return (
     <AuthBoundary
       loading={<AnalysisLoadingPage />}
       fallback={<AnalysisUnloginPage />}
     >
-      <Stack gap="none" className="gap-4 md:gap-5 xl:gap-7">
-        <Suspense fallback={<ScreenTimeSkeleton />}>
-          <FetchBoundary
-            queries={[
-              serverScreenTimeQueryOptions({
-                date,
-                period: "DAILY",
-                timeZone: SERVER_TIMEZONE.SEOUL,
-              }),
-              serverScreenTimeQueryOptions({
-                date,
-                period: "WEEKLY",
-                timeZone: SERVER_TIMEZONE.SEOUL,
-              }),
-            ]}
-          >
-            <ScreenTime date={date} />
-          </FetchBoundary>
-        </Suspense>
-        <Suspense fallback={<CategoryAnalysisSkeleton />}>
-          <FetchBoundary
-            queries={[
-              serverCategoryAnalysisQueryOptions({
-                date,
-                timeZone: SERVER_TIMEZONE.SEOUL,
-              }),
-            ]}
-          >
-            <CategoryAnalysis date={date} />
-          </FetchBoundary>
-        </Suspense>
-        <Grid
-          cols={{ base: 1, md: 2 }}
-          gap="none"
-          className="gap-4 md:gap-5 xl:gap-7"
-        >
-          <Suspense fallback={<WorkPatternSkeleton />}>
-            <FetchBoundary
-              queries={[
-                serverWorkPatternQueryOptions({
-                  date,
-                  timeZone: SERVER_TIMEZONE.SEOUL,
-                }),
-              ]}
-            >
-              <WorkPattern date={date} />
-            </FetchBoundary>
-          </Suspense>
-          <ErrorBoundary fallback={<EmptyTodayTimeThief />}>
-            <Suspense fallback={<TodayTimeThiefSkeleton />}>
+      <HydrationBoundary state={dehydrateState(queryClient)}>
+        <TimeZoneProvider timeZone={timeZone}>
+          <Stack gap="none" className="gap-4 md:gap-5 xl:gap-7">
+            <Suspense fallback={<ScreenTimeSkeleton />}>
               <FetchBoundary
                 queries={[
-                  serverLongestStayedWebsiteQueryOptions({
+                  serverScreenTimeQueryOptions({
                     date,
-                    timeZone: SERVER_TIMEZONE.SEOUL,
+                    period: "DAILY",
+                    timeZone,
+                  }),
+                  serverScreenTimeQueryOptions({
+                    date,
+                    period: "WEEKLY",
+                    timeZone,
                   }),
                 ]}
               >
-                <TodayTimeThief date={date} />
+                <ScreenTime date={date} />
               </FetchBoundary>
             </Suspense>
-          </ErrorBoundary>
-        </Grid>
-        <Suspense fallback={<TopVisitedSitesSkeleton />}>
-          <FetchBoundary
-            queries={[
-              serverFrequentlyVisitedSitesQueryOptions({
-                date,
-                limit: 10,
-                timeZone: SERVER_TIMEZONE.SEOUL,
-              }),
-            ]}
-          >
-            <TopVisitedSites date={date} />
-          </FetchBoundary>
-        </Suspense>
-      </Stack>
-      <TrackDomainSetting />
+            <Suspense fallback={<CategoryAnalysisSkeleton />}>
+              <FetchBoundary
+                queries={[
+                  serverCategoryAnalysisQueryOptions({
+                    date,
+                    timeZone,
+                  }),
+                ]}
+              >
+                <CategoryAnalysis date={date} />
+              </FetchBoundary>
+            </Suspense>
+            <Grid
+              cols={{ base: 1, md: 2 }}
+              gap="none"
+              className="gap-4 md:gap-5 xl:gap-7"
+            >
+              <Suspense fallback={<WorkPatternSkeleton />}>
+                <FetchBoundary
+                  queries={[
+                    serverWorkPatternQueryOptions({
+                      date,
+                      timeZone,
+                    }),
+                  ]}
+                >
+                  <WorkPattern date={date} />
+                </FetchBoundary>
+              </Suspense>
+              <ErrorBoundary fallback={<EmptyTodayTimeThief />}>
+                <Suspense fallback={<TodayTimeThiefSkeleton />}>
+                  <FetchBoundary
+                    queries={[
+                      serverLongestStayedWebsiteQueryOptions({
+                        date,
+                        timeZone,
+                      }),
+                    ]}
+                  >
+                    <TodayTimeThief date={date} />
+                  </FetchBoundary>
+                </Suspense>
+              </ErrorBoundary>
+            </Grid>
+            <Suspense fallback={<TopVisitedSitesSkeleton />}>
+              <FetchBoundary
+                queries={[
+                  serverFrequentlyVisitedSitesQueryOptions({
+                    date,
+                    limit: 10,
+                    timeZone,
+                  }),
+                ]}
+              >
+                <TopVisitedSites date={date} />
+              </FetchBoundary>
+            </Suspense>
+          </Stack>
+          <TrackDomainSetting />
+        </TimeZoneProvider>
+      </HydrationBoundary>
     </AuthBoundary>
   );
 }

--- a/apps/web/src/entities/language/index.ts
+++ b/apps/web/src/entities/language/index.ts
@@ -7,3 +7,4 @@ export {
 export { default as useLanguage } from "./model/use-language";
 export { default as useTimeZone } from "./model/use-time-zone";
 export { default as LanguageSelect } from "./ui/LanguageSelect";
+export { TimeZoneProvider } from "./ui/TimeZoneProvider";

--- a/apps/web/src/entities/language/model/use-language.ts
+++ b/apps/web/src/entities/language/model/use-language.ts
@@ -8,6 +8,7 @@ import { useGetUserProfile } from "@/features/settings/api/user-query.client";
 
 const useLanguage = () => {
   const storedLanguage = useLanguageStore((s) => s.localize);
+
   const setLanguage = useLanguageStore((s) => s.setLanguage);
   const { isLoggedIn } = useAuth();
   const { data: profileLanguage } = useGetUserProfile({
@@ -15,8 +16,12 @@ const useLanguage = () => {
     enabled: isLoggedIn,
   });
 
-  const language: LanguageType = profileLanguage
+  const languageFromProfile = profileLanguage
     ? (LANGUAGE_MAP[profileLanguage] ?? DEFAULT_LANGUAGE)
+    : undefined;
+
+  const language: LanguageType = isLoggedIn
+    ? (languageFromProfile ?? storedLanguage)
     : storedLanguage;
 
   return { language, setLanguage };

--- a/apps/web/src/entities/language/model/use-time-zone.ts
+++ b/apps/web/src/entities/language/model/use-time-zone.ts
@@ -1,13 +1,31 @@
-import { SERVER_TIMEZONE } from "@recap/lib";
+import { useMemo } from "react";
 
+import { useAuth } from "@/entities/auth/ui";
+import { useLanguageStore } from "@/entities/language/model/language.store";
+import { useTimeZoneContext } from "@/entities/language/ui/TimeZoneProvider";
 import { useGetUserProfile } from "@/features/settings/api/user-query.client";
+import { LANGUAGE_TO_PROFILE } from "@/features/settings/config/language.const";
 
 const useTimeZone = () => {
-  const { data } = useGetUserProfile({
+  const { isLoggedIn } = useAuth();
+  const timeZoneFromServer = useTimeZoneContext();
+  const language = useLanguageStore((s) => s.localize);
+
+  const { data: timeZoneFromProfile } = useGetUserProfile({
     select: (data) => data?.data?.timeZone,
+    enabled: isLoggedIn,
   });
 
-  return data ?? SERVER_TIMEZONE.UTC;
+  const timeZoneFromLocal = useMemo(
+    () => LANGUAGE_TO_PROFILE[language].timeZone,
+    [language],
+  );
+
+  if (isLoggedIn) {
+    return timeZoneFromProfile ?? timeZoneFromServer ?? timeZoneFromLocal;
+  }
+
+  return timeZoneFromLocal;
 };
 
 export default useTimeZone;

--- a/apps/web/src/entities/language/ui/TimeZoneProvider.tsx
+++ b/apps/web/src/entities/language/ui/TimeZoneProvider.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { createContext, type ReactNode, useContext } from "react";
+import type { TimeZoneSchemaType } from "@recap/api";
+
+const TimeZoneContext = createContext<TimeZoneSchemaType | null>(null);
+
+const TimeZoneProvider = ({
+  timeZone,
+  children,
+}: {
+  timeZone: TimeZoneSchemaType;
+  children: ReactNode;
+}) => {
+  return (
+    <TimeZoneContext.Provider value={timeZone}>
+      {children}
+    </TimeZoneContext.Provider>
+  );
+};
+
+const useTimeZoneContext = () => useContext(TimeZoneContext);
+
+export { TimeZoneProvider, useTimeZoneContext };

--- a/apps/web/src/entities/login/ui/LoginButton.tsx
+++ b/apps/web/src/entities/login/ui/LoginButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback } from "react";
+import { useRouter } from "next/navigation";
 import { useLocale } from "@recap/i18n";
 import { useQueryClient } from "@recap/react-query";
 import { Button, cn } from "@recap/ui";
@@ -13,7 +14,7 @@ import RightIcon from "@/shared/assets/icons/arrow-right.svg";
 const LoginButton = ({ className }: { className?: string }) => {
   const { t } = useLocale("settings");
   const { refreshAuth } = useAuth();
-
+  const router = useRouter();
   const queryClient = useQueryClient();
 
   const onLoginSuccess = useCallback(async () => {
@@ -21,7 +22,8 @@ const LoginButton = ({ className }: { className?: string }) => {
     queryClient.removeQueries({
       queryKey: USER_KEYS.details(),
     });
-  }, [queryClient, refreshAuth]);
+    router.refresh();
+  }, [queryClient, refreshAuth, router]);
 
   const { ready, login } = useGoogleTokenLogin({
     onLoginSuccess,

--- a/apps/web/src/entities/login/ui/LogoutButton.tsx
+++ b/apps/web/src/entities/login/ui/LogoutButton.tsx
@@ -1,8 +1,10 @@
 import { useLocale } from "@recap/i18n";
+import { useQueryClient } from "@recap/react-query";
 import { Button } from "@recap/ui";
 
 import { logoutSession } from "@/entities/auth/api/auth-session-client";
 import { useAuth } from "@/entities/auth/ui";
+import { USER_KEYS } from "@/features/settings/api/query-keys";
 import RightIcon from "@/shared/assets/icons/arrow-right.svg";
 import { useAnalytics } from "@/shared/lib/analytics";
 
@@ -10,6 +12,7 @@ const LogoutButton = () => {
   const { t } = useLocale("settings");
 
   const { refreshAuth } = useAuth();
+  const queryClient = useQueryClient();
 
   const analytics = useAnalytics();
 
@@ -19,6 +22,9 @@ const LogoutButton = () => {
 
       analytics.identify(null);
       analytics.track("logout", {});
+      queryClient.removeQueries({
+        queryKey: USER_KEYS.details(),
+      });
       await refreshAuth();
     } catch (err) {
       analytics.track("web_error", {

--- a/apps/web/src/features/settings/api/user-query.server.ts
+++ b/apps/web/src/features/settings/api/user-query.server.ts
@@ -1,6 +1,11 @@
-import type { Envelope, UserProfileType } from "@recap/api";
+import type { Envelope, TimeZoneSchemaType, UserProfileType } from "@recap/api";
 import { UserAPIService } from "@recap/api";
-import { type FetchQueryOptions, queryOptions } from "@tanstack/react-query";
+import { Language, SERVER_TIMEZONE } from "@recap/lib";
+import {
+  type FetchQueryOptions,
+  type QueryClient,
+  queryOptions,
+} from "@tanstack/react-query";
 
 import { createServerAuthedRestAPI } from "@/entities/auth/lib/create-server-authed-rest";
 
@@ -29,3 +34,33 @@ export const serverUserProfileQueryOptions = (): FetchQueryOptions<
     queryFn: () => serverUserAPIService.getUserProfile(),
     retry: false,
   });
+
+const resolveTimeZoneFromProfile = (
+  profile: UserProfileType | undefined,
+): TimeZoneSchemaType => {
+  if (profile?.timeZone) {
+    return profile.timeZone;
+  }
+
+  if (profile?.language === Language.KOREAN) {
+    return SERVER_TIMEZONE.SEOUL;
+  }
+
+  return SERVER_TIMEZONE.UTC;
+};
+
+export const getServerUserTimeZone = async (
+  queryClient: QueryClient,
+): Promise<TimeZoneSchemaType | null> => {
+  await queryClient.prefetchQuery(serverUserProfileQueryOptions());
+
+  const profile = queryClient.getQueryData<UserProfileResponse>(
+    USER_KEYS.details(),
+  );
+
+  if (!profile?.data) {
+    return null;
+  }
+
+  return resolveTimeZoneFromProfile(profile.data);
+};

--- a/apps/web/src/features/settings/ui/LanguageSection.tsx
+++ b/apps/web/src/features/settings/ui/LanguageSection.tsx
@@ -38,6 +38,8 @@ const LanguageSection = ({ disabled = false }: LanguageSectionProps) => {
 
   const { mutate, isPending } = usePatchUserProfile({
     onSuccess: () => {
+      setLanguage(selectedLanguage);
+
       queryClient.invalidateQueries({
         queryKey: USER_KEYS.details(),
       });
@@ -68,7 +70,15 @@ const LanguageSection = ({ disabled = false }: LanguageSectionProps) => {
       mutate(LANGUAGE_TO_PROFILE[selectedLanguage]);
       return;
     }
+
     setLanguage(selectedLanguage);
+    showToast({
+      type: "success",
+      message: i18n.t("languageChange.success", {
+        lng: selectedLanguage,
+        ns: "settings",
+      }),
+    });
   };
 
   return (

--- a/apps/web/src/pages/auth/ui/ExtensionAuthPage.tsx
+++ b/apps/web/src/pages/auth/ui/ExtensionAuthPage.tsx
@@ -2,9 +2,11 @@
 
 import { useCallback, useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useQueryClient } from "@recap/react-query";
 
 import { useAuth } from "@/entities/auth/ui";
 import { useGoogleTokenLogin } from "@/entities/login/model/use-google-token-login";
+import { USER_KEYS } from "@/features/settings/api/query-keys";
 
 function buildRedirectPath(redirect: string | null, date: string | null) {
   const path = redirect && redirect.startsWith("/") ? redirect : "/analysis";
@@ -18,6 +20,7 @@ function buildRedirectPath(redirect: string | null, date: string | null) {
 export default function ExtensionAuthPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
   const { refreshAuth, unLogin } = useAuth();
   const startedRef = useRef(false);
 
@@ -27,8 +30,11 @@ export default function ExtensionAuthPage() {
 
   const onLoginSuccess = useCallback(async () => {
     await refreshAuth();
+    queryClient.removeQueries({
+      queryKey: USER_KEYS.details(),
+    });
     router.replace(buildRedirectPath(redirect, date));
-  }, [date, redirect, refreshAuth, router]);
+  }, [date, queryClient, redirect, refreshAuth, router]);
 
   const { login } = useGoogleTokenLogin({ onLoginSuccess });
 

--- a/packages/ui/src/toast.tsx
+++ b/packages/ui/src/toast.tsx
@@ -74,7 +74,12 @@ function Toast({
 
 function ToastProvider({ children }: ToastProviderProps) {
   const [toasts, setToasts] = React.useState<ToastItem[]>([]);
+  const [isMounted, setIsMounted] = React.useState(false);
   const nextId = React.useRef(0);
+
+  React.useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   const dismissToast = React.useCallback((id: number) => {
     setToasts((current) => current.filter((toast) => toast.id !== id));
@@ -102,7 +107,7 @@ function ToastProvider({ children }: ToastProviderProps) {
   return (
     <ToastContext.Provider value={value}>
       {children}
-      {typeof document !== "undefined" &&
+      {isMounted &&
         createPortal(
           <div className="pointer-events-none fixed inset-x-4 top-12 z-50 flex flex-col items-center gap-2">
             {toasts.map((toast) => (


### PR DESCRIPTION
## 작업 내용

- Extension 카테고리 링크의 도메인과 사용 시간에 최대 너비 및 말줄임 스타일을 적용했습니다.
- 사용자 프로필의 timezone을 서버에서 먼저 조회하고, 해당 timezone을 기준으로 분석 데이터를 prefetch하도록 수정했습니다.
- 서버에서 조회한 profile 및 timezone 상태를 클라이언트에 hydrate하여 UTC로 중복 요청되는 문제를 해결했습니다.
- 로그인·로그아웃 및 언어 변경 시 프로필 캐시와 로컬 언어 상태가 동기화되도록 수정했습니다.
- Toast Portal을 클라이언트 마운트 이후 렌더링하여 hydration mismatch를 해결했습니다.

## 작업 목적

- QA 과정에서 확인된 긴 도메인 레이아웃 깨짐을 방지합니다.
- SSR과 클라이언트가 동일한 timezone 및 사용자 상태를 사용하도록 보장합니다.
- 서버와 클라이언트의 최초 렌더 결과 차이로 발생하는 hydration 오류를 방지합니다.

### 스크린샷 (선택)

- 필요 시 첨부
