### PR TITLE
fix: 병렬 refresh 중복 호출 방지 및 토큰 갱신 경로 정리

### DIFF
--- a/apps/extension/src/entities/auth/config/auth-token.const.ts
+++ b/apps/extension/src/entities/auth/config/auth-token.const.ts
@@ -1,0 +1,2 @@
+export const ACCESS_TOKEN_MAX_AGE_MS = 60 * 15 * 1000;
+export const REFRESH_TOKEN_MAX_AGE_MS = 60 * 60 * 24 * 30 * 1000;

--- a/apps/extension/src/entities/auth/ui/AuthProvider.tsx
+++ b/apps/extension/src/entities/auth/ui/AuthProvider.tsx
@@ -22,8 +22,8 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
 
   const refreshAuth = useCallback(async () => {
     try {
-      const accessToken = await tokenStore.getAccess();
-      setIsLoggedIn(accessToken !== null);
+      const refreshToken = await tokenStore.getRefresh();
+      setIsLoggedIn(refreshToken !== null);
     } catch {
       setIsLoggedIn(false);
     } finally {
@@ -37,11 +37,11 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
   }, []);
 
   useEffect(() => {
-    void refreshAuth();
+    refreshAuth();
   }, [refreshAuth]);
 
   useBrowserMessage(MESSAGE_TYPE.AUTH_CHANGED, () => {
-    void refreshAuth();
+    refreshAuth();
   });
 
   const value = useMemo<AuthValue>(

--- a/apps/extension/src/entities/history/model/storage.type.ts
+++ b/apps/extension/src/entities/history/model/storage.type.ts
@@ -17,13 +17,17 @@ export interface StorageSession extends PageSnapshot {
 export interface StorageData {
   sessions: Record<string, StorageSession>;
   accessToken: string | null;
+  accessTokenExpiresAt: number | null;
   refreshToken: string | null;
+  refreshTokenExpiresAt: number | null;
   excludedDomains: string[];
 }
 
 export const defaultStorage: StorageData = {
   sessions: {},
   accessToken: null,
+  accessTokenExpiresAt: null,
   refreshToken: null,
+  refreshTokenExpiresAt: null,
   excludedDomains: [],
 };

--- a/apps/extension/src/shared/lib/token-store.ts
+++ b/apps/extension/src/shared/lib/token-store.ts
@@ -1,13 +1,19 @@
+import {
+  ACCESS_TOKEN_MAX_AGE_MS,
+  REFRESH_TOKEN_MAX_AGE_MS,
+} from "@/entities/auth/config/auth-token.const";
 import { getStorage, setStorage } from "@/shared/lib/storage";
 
 export const tokenStore = {
   async getAccess(): Promise<string | null> {
-    const result = await getStorage(["accessToken"]);
+    const result = await getStorage(["accessToken", "accessTokenExpiresAt"]);
+
     return result.accessToken;
   },
 
   async getRefresh(): Promise<string | null> {
-    const result = await getStorage(["refreshToken"]);
+    const result = await getStorage(["refreshToken", "refreshTokenExpiresAt"]);
+
     return result.refreshToken;
   },
 
@@ -15,16 +21,22 @@ export const tokenStore = {
     accessToken: string;
     refreshToken: string;
   }): Promise<void> {
+    const now = Date.now();
+
     await setStorage({
       accessToken: tokens.accessToken,
+      accessTokenExpiresAt: now + ACCESS_TOKEN_MAX_AGE_MS,
       refreshToken: tokens.refreshToken,
+      refreshTokenExpiresAt: now + REFRESH_TOKEN_MAX_AGE_MS,
     });
   },
 
   async clear(): Promise<void> {
     await setStorage({
       accessToken: null,
+      accessTokenExpiresAt: null,
       refreshToken: null,
+      refreshTokenExpiresAt: null,
     });
   },
 };

--- a/apps/web/app/api/auth/refresh/route.ts
+++ b/apps/web/app/api/auth/refresh/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+
+import { refreshAuthTokens } from "@/entities/auth/lib/refresh-auth-tokens";
+import { serverTokenStore } from "@/entities/auth/model/server-token-store";
+
+export async function POST() {
+  const refreshToken = await serverTokenStore.getRefresh();
+
+  if (!refreshToken) {
+    return NextResponse.json(
+      { message: "Refresh token not found" },
+      { status: 401 },
+    );
+  }
+
+  const tokens = await refreshAuthTokens(refreshToken);
+
+  if (!tokens) {
+    await serverTokenStore.clear();
+
+    return NextResponse.json({ message: "Refresh failed" }, { status: 401 });
+  }
+
+  await serverTokenStore.set(tokens);
+
+  return NextResponse.json(tokens);
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,19 +1,72 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-import { ACCESS_TOKEN_COOKIE } from "@/entities/auth/config/auth-cookie-keys.const";
+import {
+  ACCESS_TOKEN_COOKIE,
+  REFRESH_TOKEN_COOKIE,
+} from "@/entities/auth/config/auth-cookie-keys.const";
+import {
+  ACCESS_TOKEN_MAX_AGE,
+  REFRESH_TOKEN_MAX_AGE,
+  TOKEN_COOKIE_OPTIONS,
+} from "@/entities/auth/config/auth-cookie-options.const";
+import { isJwtExpired } from "@/entities/auth/lib/jwt-expiry";
+import { refreshAuthTokens } from "@/entities/auth/lib/refresh-auth-tokens";
 
-export function middleware(request: NextRequest) {
-  const hasAccessToken = Boolean(
-    request.cookies.get(ACCESS_TOKEN_COOKIE)?.value,
-  );
+function withSessionHeader(response: NextResponse, hasSession: boolean) {
+  response.headers.set("x-auth-session", hasSession ? "1" : "0");
+  return response;
+}
 
-  const response = NextResponse.next();
-  response.headers.set("x-auth-session", hasAccessToken ? "1" : "0");
+function clearSession(response: NextResponse) {
+  response.cookies.delete(ACCESS_TOKEN_COOKIE);
+  response.cookies.delete(REFRESH_TOKEN_COOKIE);
+
+  return response;
+}
+
+export async function middleware(request: NextRequest) {
+  const accessToken = request.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
+  const refreshToken = request.cookies.get(REFRESH_TOKEN_COOKIE)?.value;
+
+  /**
+   * 쿠키 maxAge와 실제 토큰 만료가 다를 수 있으므로 존재 여부가 아니라 exp로 판단한다.
+   */
+  if (accessToken && !isJwtExpired(accessToken)) {
+    return withSessionHeader(NextResponse.next(), true);
+  }
+
+  if (!refreshToken || isJwtExpired(refreshToken)) {
+    return clearSession(withSessionHeader(NextResponse.next(), false));
+  }
+
+  /**
+   * Server Component는 쿠키를 쓸 수 없으므로 렌더가 시작되기 전인 여기서 갱신을 끝낸다.
+   * 이번 요청의 SSR도 새 토큰을 읽도록 request 쿠키까지 교체한다.
+   */
+  const tokens = await refreshAuthTokens(refreshToken);
+
+  if (!tokens) {
+    return clearSession(withSessionHeader(NextResponse.next(), false));
+  }
+
+  request.cookies.set(ACCESS_TOKEN_COOKIE, tokens.accessToken);
+  request.cookies.set(REFRESH_TOKEN_COOKIE, tokens.refreshToken);
+
+  const response = withSessionHeader(NextResponse.next({ request }), true);
+
+  response.cookies.set(ACCESS_TOKEN_COOKIE, tokens.accessToken, {
+    ...TOKEN_COOKIE_OPTIONS,
+    maxAge: ACCESS_TOKEN_MAX_AGE,
+  });
+  response.cookies.set(REFRESH_TOKEN_COOKIE, tokens.refreshToken, {
+    ...TOKEN_COOKIE_OPTIONS,
+    maxAge: REFRESH_TOKEN_MAX_AGE,
+  });
 
   return response;
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
 };

--- a/apps/web/src/entities/auth/config/auth-cookie-options.const.ts
+++ b/apps/web/src/entities/auth/config/auth-cookie-options.const.ts
@@ -17,5 +17,5 @@ export const HTTP_ONLY_COOKIE_OPTIONS = {
 };
 
 export const ACCESS_TOKEN_MAX_AGE = 60 * 15; // 15분
-export const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 14; // 14일
+export const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 30; // 30일
 export const OAUTH_TOKEN_MAX_AGE = 60 * 60; // 1시간

--- a/apps/web/src/entities/auth/lib/create-authed-rest.ts
+++ b/apps/web/src/entities/auth/lib/create-authed-rest.ts
@@ -1,17 +1,48 @@
 import type { RestAPIProtocol } from "@recap/api";
 import { APIError, RestAPI, RestAPIInstance } from "@recap/api";
 
-import { authUnTokenAPIService } from "@/entities/auth/api";
 import { getBackendUrl } from "@/entities/auth/lib/backend-url";
+import type { AuthTokenPair } from "@/entities/auth/lib/refresh-auth-tokens";
 import { clientTokenStore } from "@/entities/auth/model/client-token-store";
-
-function isRefreshUrl(url: string) {
-  return url.includes("/auth/refresh");
-}
 
 type CreateAuthedRestAPIOptions = {
   apiBaseURL?: string;
 };
+
+/**
+ * 동시에 여러 요청이 401을 반환하더라도
+ * refresh 요청은 하나만 실행하도록 공유하는 Promise
+ */
+let refreshPromise: Promise<AuthTokenPair> | null = null;
+
+/**
+ * 갱신은 Route Handler에만 맡긴다.
+ * 브라우저와 SSR이 항상 같은 쿠키를 보도록 갱신 창구를 하나로 유지하기 위함.
+ */
+async function requestRefresh(): Promise<AuthTokenPair> {
+  const res = await fetch("/api/auth/refresh", {
+    method: "POST",
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  });
+
+  if (!res.ok) {
+    throw new APIError("Failed to refresh tokens", {
+      code: "REFRESH_TOKEN_NOT_FOUND",
+      status: 401,
+    });
+  }
+
+  return (await res.json()) as AuthTokenPair;
+}
+
+function refreshAccessToken(): Promise<AuthTokenPair> {
+  refreshPromise ??= requestRefresh().finally(() => {
+    refreshPromise = null;
+  });
+
+  return refreshPromise;
+}
 
 export function createAuthedRestAPI(
   baseURL?: string,
@@ -36,25 +67,12 @@ export function createAuthedRestAPI(
 
     onResponse: async ({ url, init, res }) => {
       if (res.status !== 401) return res;
-      if (isRefreshUrl(url)) return res;
 
       try {
-        const refreshToken = clientTokenStore.getRefresh();
-        if (!refreshToken) {
-          throw new APIError("Refresh token not found", {
-            code: "REFRESH_TOKEN_NOT_FOUND",
-            status: 401,
-          });
-        }
-
-        const refreshRes = await authUnTokenAPIService.refreshTokens({
-          refreshToken,
-        });
-
-        clientTokenStore.set(refreshRes);
+        const tokens = await refreshAccessToken();
 
         const retryHeaders = new Headers(init.headers);
-        retryHeaders.set("Authorization", `Bearer ${refreshRes.accessToken}`);
+        retryHeaders.set("Authorization", `Bearer ${tokens.accessToken}`);
         retryHeaders.set("Accept", "application/json");
 
         return fetch(url, { ...init, headers: retryHeaders });

--- a/apps/web/src/entities/auth/lib/create-server-authed-rest.ts
+++ b/apps/web/src/entities/auth/lib/create-server-authed-rest.ts
@@ -1,13 +1,8 @@
 import type { RestAPIProtocol } from "@recap/api";
-import { APIError, RestAPI, RestAPIInstance } from "@recap/api";
+import { RestAPI, RestAPIInstance } from "@recap/api";
 
-import { authUnTokenAPIService } from "@/entities/auth/api";
 import { getBackendUrl } from "@/entities/auth/lib/backend-url";
 import { serverTokenStore } from "@/entities/auth/model/server-token-store";
-
-function isRefreshUrl(url: string) {
-  return url.includes("/auth/refresh");
-}
 
 type CreateServerAuthedRestAPIOptions = {
   apiBaseURL?: string;
@@ -20,6 +15,11 @@ export function createServerAuthedRestAPI(
   const apiBaseURL = options?.apiBaseURL ?? "v1";
   const resolvedBaseURL = baseURL ?? getBackendUrl();
 
+  /**
+   * Server Component 렌더 중에는 Set-Cookie를 보낼 수 없어 회전된 토큰을 저장할 수 없다.
+   * 여기서 refresh를 시도하면 1회용 refresh token만 소모하고 쿠키에는 무효한 토큰이 남으므로,
+   * 갱신은 middleware와 /api/auth/refresh에서만 수행한다.
+   */
   const instance = new RestAPIInstance(resolvedBaseURL, {
     withCredentials: false,
     headers: { Accept: "application/json" },
@@ -32,41 +32,6 @@ export function createServerAuthedRestAPI(
       headers.set("Authorization", `Bearer ${accessToken}`);
 
       return { url, init: { ...init, headers } };
-    },
-
-    onResponse: async ({ url, init, res }) => {
-      if (res.status !== 401) return res;
-      if (isRefreshUrl(url)) return res;
-
-      try {
-        const refreshToken = await serverTokenStore.getRefresh();
-        if (!refreshToken) {
-          throw new APIError("Refresh token not found", {
-            code: "REFRESH_TOKEN_NOT_FOUND",
-            status: 401,
-          });
-        }
-
-        const refreshRes = await authUnTokenAPIService.refreshTokens({
-          refreshToken,
-        });
-
-        await serverTokenStore.set(refreshRes);
-
-        const retryHeaders = new Headers(init.headers);
-        retryHeaders.set("Authorization", `Bearer ${refreshRes.accessToken}`);
-        retryHeaders.set("Accept", "application/json");
-
-        return fetch(url, { ...init, headers: retryHeaders });
-      } catch (error) {
-        await serverTokenStore.clear();
-
-        if (error instanceof APIError) {
-          throw error;
-        }
-
-        return res;
-      }
     },
   });
 

--- a/apps/web/src/entities/auth/lib/jwt-expiry.ts
+++ b/apps/web/src/entities/auth/lib/jwt-expiry.ts
@@ -1,0 +1,39 @@
+type JwtPayload = { exp?: number };
+
+function decodeBase64Url(value: string): string | null {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(
+    normalized.length + ((4 - (normalized.length % 4)) % 4),
+    "=",
+  );
+
+  try {
+    return atob(padded);
+  } catch {
+    return null;
+  }
+}
+
+/** 서명 검증은 백엔드가 한다. 여기서는 갱신 시점 판단용으로 만료 시각만 읽는다. */
+export function getJwtExpiresAt(token: string): number | null {
+  const payload = token.split(".")[1];
+  if (!payload) return null;
+
+  const decoded = decodeBase64Url(payload);
+  if (!decoded) return null;
+
+  try {
+    const { exp } = JSON.parse(decoded) as JwtPayload;
+    return typeof exp === "number" ? exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+/** exp를 읽지 못하면 만료로 단정하지 않고 백엔드 판단에 맡긴다. */
+export function isJwtExpired(token: string, leewayMs = 10_000): boolean {
+  const expiresAt = getJwtExpiresAt(token);
+  if (expiresAt === null) return false;
+
+  return Date.now() + leewayMs >= expiresAt;
+}

--- a/apps/web/src/entities/auth/lib/refresh-auth-tokens.ts
+++ b/apps/web/src/entities/auth/lib/refresh-auth-tokens.ts
@@ -1,0 +1,54 @@
+import { buildBackendApiUrl } from "@/entities/auth/lib/backend-url";
+import { parseApiPayload } from "@/entities/auth/lib/parse-api-payload";
+
+export type AuthTokenPair = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+/**
+ * refresh token은 사용하는 순간 회전되어 이전 토큰이 무효해진다.
+ * 같은 토큰으로 들어온 동시 요청은 하나의 호출로 합쳐 중복 소모를 막는다.
+ */
+const inFlightByToken = new Map<string, Promise<AuthTokenPair | null>>();
+
+async function requestRefresh(
+  refreshToken: string,
+): Promise<AuthTokenPair | null> {
+  const res = await fetch(buildBackendApiUrl("v1", "auth/refresh"), {
+    method: "POST",
+    cache: "no-store",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ refreshToken }),
+  }).catch(() => null);
+
+  if (!res?.ok) return null;
+
+  const body = await res.json().catch(() => ({}));
+  const tokens = parseApiPayload<Partial<AuthTokenPair>>(body);
+
+  if (!tokens?.accessToken || !tokens?.refreshToken) return null;
+
+  return {
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+  };
+}
+
+export function refreshAuthTokens(
+  refreshToken: string,
+): Promise<AuthTokenPair | null> {
+  const inFlight = inFlightByToken.get(refreshToken);
+  if (inFlight) return inFlight;
+
+  const refreshPromise = requestRefresh(refreshToken).finally(() => {
+    inFlightByToken.delete(refreshToken);
+  });
+
+  inFlightByToken.set(refreshToken, refreshPromise);
+
+  return refreshPromise;
+}

--- a/apps/web/src/shared/lib/analytics/gtag-client.ts
+++ b/apps/web/src/shared/lib/analytics/gtag-client.ts
@@ -15,9 +15,6 @@ function send(command: string, ...args: unknown[]): void {
   if (!isBrowser()) return;
 
   if (isDev) {
-    console.groupCollapsed(`[analytics] gtag(${command})`);
-    console.log(args);
-    console.groupEnd();
     return;
   }
 


### PR DESCRIPTION
## 작업 내용

- Web: access 만료 시 middleware에서 refresh를 수행하고, 쿠키를 갱신한 뒤 SSR/클라이언트에 동일 세션을 반영
- Web: `/api/auth/refresh` Route Handler를 추가해 클라이언트 401 재시도 시 갱신 창구를 단일화
- Web: `refreshAuthTokens` / 클라이언트 `createAuthedRestAPI`에서 in-flight Promise로 병렬 refresh 중복 호출을 합침 (회전형 refresh token 중복 소모 방지)
- Web: Server Component용 `createServerAuthedRestAPI`에서는 refresh를 제거 (렌더 중 Set-Cookie 불가 → 토큰만 소모되는 문제 방지)
- Web: JWT `exp` 기반 만료 판별(`jwt-expiry`) 추가, refresh 쿠키 maxAge를 30일로 변경
- Extension: access 15분 / refresh 30일 storage TTL을 web과 맞추고, 로그인 판별을 refresh 기준으로 통일

## 작업 목적

- access 만료 후 여러 API가 동시에 401을 받아 refresh가 병렬로 나가던 문제를 막고, 1회용 refresh token이 중복 소모되어 세션이 깨지는 상황을 줄이기 위함
- Next 서버(SSR)와 브라우저가 같은 쿠키 상태를 보도록 갱신 책임을 middleware + `/api/auth/refresh`로 모으기 위함
- Web/Extension 토큰 만료 정책(access 15분, refresh 30일)을 맞춰 세션 수명을 일관되게 관리하기 위함

### 스크린샷 (선택)
