### PR TITLE
feat: ai 리캡 페이지 반응형 레이아웃 적용 

### DIFF
--- a/apps/web/src/features/ai-recap/ui/AiTimeline.tsx
+++ b/apps/web/src/features/ai-recap/ui/AiTimeline.tsx
@@ -29,8 +29,8 @@ const AiTimeline = ({ timelines }: { timelines: AiRecapTimeline[] }) => {
   );
 
   return (
-    <Card className="relative flex flex-row flex-nowrap gap-9 rounded-[1.25rem] bg-white px-9 py-8 shadow-none">
-      <CardHeader className="max-w-57 shrink-0 gap-0 p-0">
+    <Card className="relative flex flex-col gap-6 rounded-[1.25rem] bg-white px-5 py-5 shadow-none md:flex-row md:flex-nowrap md:gap-9 md:px-6 md:py-6 xl:px-9 xl:py-8">
+      <CardHeader className="shrink-0 gap-0 p-0 md:max-w-57">
         <Stack gap="none" className="gap-2">
           <CardTitle className="text-heading-rg text-gray-800">
             {t("todayRecap.aiTimelineTitle")}

--- a/apps/web/src/features/ai-recap/ui/RecapSummary.tsx
+++ b/apps/web/src/features/ai-recap/ui/RecapSummary.tsx
@@ -41,10 +41,12 @@ const RecapSummary = ({ recap }: { recap: RecapData }) => {
 
   const title = detail?.title?.trim() || "-";
   const summary = detail?.summary?.trim() || "-";
+  const recapImage =
+    (detail?.image && AI_RECAP_IMAGE[detail.image]) ?? RecapImg;
 
   return (
     <Card className="gap-0 overflow-hidden rounded-[1.25rem] bg-white p-0 shadow-none">
-      <CardHeader className="gap-0 p-10">
+      <CardHeader className="gap-0 p-5 md:p-6 xl:p-10">
         <Flex
           direction="column"
           className="items-stretch gap-6 md:flex-row md:items-end md:justify-between"
@@ -81,7 +83,7 @@ const RecapSummary = ({ recap }: { recap: RecapData }) => {
           </Flex>
         </Flex>
 
-        <Item className="mt-12 flex-nowrap items-center gap-4 self-start rounded-full border-0 bg-blue-50 p-0 px-2.5 py-2 shadow-none">
+        <Item className="mt-8 flex-nowrap items-center gap-4 self-start rounded-full border-0 bg-blue-50 p-0 px-2.5 py-2 shadow-none xl:mt-12">
           <ItemContent className="min-w-0 flex-1 flex-row flex-wrap items-center gap-4 p-0">
             <div className="flex shrink-0 items-center gap-2">
               <AIRecapIcon />
@@ -97,20 +99,30 @@ const RecapSummary = ({ recap }: { recap: RecapData }) => {
         </Item>
       </CardHeader>
 
-      <CardContent className="grid grid-cols-[1fr_464px] gap-0 border-t border-solid border-gray-100 p-0">
+      <CardContent className="grid grid-cols-1 border-t border-solid border-gray-100 p-0 md:grid-cols-[1fr_464px]">
+        <div className="relative order-1 h-97 overflow-hidden md:order-2 md:h-auto md:min-h-105">
+          <Image
+            src={recapImage}
+            alt="recapImg"
+            fill
+            sizes="(max-width: 767px) 100vw, 464px"
+            className="object-fill"
+          />
+        </div>
+
         {sections.length === 0 ? (
-          <div className="pt-6 pr-9 pb-13 pl-10">
+          <div className="order-2 px-5 py-6 md:order-1 md:px-6 md:pt-6 md:pr-9 md:pb-13 xl:px-10">
             <p className="text-body-1 text-gray-500">
               {t("todayRecap.summarySectionsEmpty")}
             </p>
           </div>
         ) : (
-          <ItemGroup className="gap-0">
+          <ItemGroup className="order-2 gap-0 md:order-1">
             {sections.map((section, index) => (
               <Item
                 key={`${section.title}-${index}`}
                 className={cn(
-                  "flex-col items-stretch rounded-none border-0 bg-transparent p-0 pt-6 pr-9 pb-13 pl-10 shadow-none",
+                  "flex-col items-stretch rounded-none border-0 bg-transparent p-0 px-5 py-6 shadow-none md:pt-6 md:pr-9 md:pb-13 md:pl-6 xl:pl-10",
                   index > 0 && "border-t border-solid border-gray-200",
                 )}
               >
@@ -129,13 +141,6 @@ const RecapSummary = ({ recap }: { recap: RecapData }) => {
             ))}
           </ItemGroup>
         )}
-
-        <Image
-          src={(detail?.image && AI_RECAP_IMAGE[detail.image]) ?? RecapImg}
-          alt="recapImg"
-          width={464}
-          height={420}
-        />
       </CardContent>
     </Card>
   );

--- a/apps/web/src/features/ai-recap/ui/TopVisitedTopics.tsx
+++ b/apps/web/src/features/ai-recap/ui/TopVisitedTopics.tsx
@@ -9,7 +9,6 @@ import {
   CardHeader,
   CardTitle,
   cn,
-  Grid,
   Item,
   ItemGroup,
 } from "@recap/ui";
@@ -17,10 +16,13 @@ import {
 import TopicCardItem from "@/features/ai-recap/ui/TopicCardItem";
 
 const KEYWORD_STYLES = [
-  "bg-gradient-04 text-heading-sb mt-5 ml-10 w-fit -rotate-[9.41deg] rounded-full border-8 border-solid border-white px-9 py-3 text-center text-white whitespace-nowrap",
-  "bg-gradient-05 text-heading-sb w-fit rotate-[11.17deg] rounded-full border-8 border-solid border-white px-9 py-3 text-center text-white whitespace-nowrap",
-  "bg-gradient-06 text-heading-sb w-fit -rotate-[10.56deg] rounded-full border-8 border-solid border-white px-9 py-3 text-center text-white whitespace-nowrap",
+  "bg-gradient-04 mt-5 ml-10 -rotate-[9.41deg]",
+  "bg-gradient-05 rotate-[11.17deg]",
+  "bg-gradient-06 -rotate-[10.56deg]",
 ] as const;
+
+const KEYWORD_BASE_STYLE =
+  "text-heading-sb w-fit rounded-full border-8 border-solid border-white px-9 py-3 text-center text-white whitespace-nowrap shadow-none";
 
 const TOPIC_PLACEHOLDER_COUNT = 3;
 
@@ -34,55 +36,58 @@ const TopVisitedTopics = ({ topics }: { topics: AiRecapTopic[] }) => {
   const topicCards = useMemo(() => topics.slice(0, 3), [topics]);
   const isEmpty = topicCards.length === 0;
 
+  const topicItems = isEmpty
+    ? Array.from({ length: TOPIC_PLACEHOLDER_COUNT }, (_, index) => (
+        <TopicCardItem
+          key={index}
+          title="-"
+          content={t("todayRecap.topicsEmpty")}
+          isPlaceholder
+          className={cn("min-w-0 md:flex-1", index === 2 && "col-span-2")}
+        />
+      ))
+    : topicCards.map((topic, index) => (
+        <TopicCardItem
+          key={`${topic.title}-${index}`}
+          title={topic.title}
+          content={topic.content}
+          className={cn("min-w-0 md:flex-1", index === 2 && "col-span-2")}
+        />
+      ));
+
   return (
-    <Card className="gap-0 rounded-[1.25rem] bg-white px-9 py-8 shadow-none">
+    <Card className="gap-0 rounded-[1.25rem] bg-white px-5 py-5 shadow-none md:px-6 md:py-6 xl:px-9 xl:py-8">
       <CardHeader className="gap-0 p-0">
         <CardTitle className="text-heading-rg text-gray-800">
           {t("todayRecap.mostViewedTopicsTitle")}
         </CardTitle>
       </CardHeader>
 
-      <CardContent className="mt-6 p-0">
-        <Grid cols={4} gap="none" className="h-74 gap-4">
-          <Item className="relative flex-col items-stretch overflow-hidden rounded-[1.25rem] border-0 bg-blue-50 px-6.5 py-6 shadow-none">
-            {topKeywords.length === 0 ? (
-              <p className="text-body-1 text-gray-500">
-                {t("todayRecap.topicsEmpty")}
-              </p>
-            ) : (
-              <ItemGroup className="gap-0">
-                {topKeywords.map((keyword, index) => (
-                  <Item
-                    key={`${keyword}-${index}`}
-                    className={cn(
-                      "rounded-none border-0 bg-transparent p-0 shadow-none",
-                      KEYWORD_STYLES[index % KEYWORD_STYLES.length],
-                    )}
-                  >
-                    #{keyword}
-                  </Item>
-                ))}
-              </ItemGroup>
-            )}
-          </Item>
-
-          {isEmpty
-            ? Array.from({ length: TOPIC_PLACEHOLDER_COUNT }, (_, index) => (
-                <TopicCardItem
-                  key={index}
-                  title="-"
-                  content={t("todayRecap.topicsEmpty")}
-                  isPlaceholder
-                />
-              ))
-            : topicCards.map((topic, index) => (
-                <TopicCardItem
-                  key={`${topic.title}-${index}`}
-                  title={topic.title}
-                  content={topic.content}
-                />
+      <CardContent className="mt-6 flex flex-col gap-4 p-0 md:h-73.75 md:flex-row">
+        {/* 키워드 배치는 화면 크기와 무관하게 고정하고, 영역 중앙에 둔다. */}
+        <Item className="relative h-73.75 w-full min-w-0 flex-col items-center justify-center overflow-hidden rounded-[1.25rem] border-0 bg-blue-50 px-6.5 py-6 shadow-none md:h-full md:w-auto md:flex-1">
+          {topKeywords.length === 0 ? (
+            <p className="text-body-1 text-gray-500">
+              {t("todayRecap.topicsEmpty")}
+            </p>
+          ) : (
+            <ItemGroup className="w-fit gap-0">
+              {topKeywords.map((keyword, index) => (
+                <Item
+                  key={`${keyword}-${index}`}
+                  className={cn(
+                    KEYWORD_BASE_STYLE,
+                    KEYWORD_STYLES[index % KEYWORD_STYLES.length],
+                  )}
+                >
+                  #{keyword}
+                </Item>
               ))}
-        </Grid>
+            </ItemGroup>
+          )}
+        </Item>
+
+        <div className="grid grid-cols-2 gap-4 md:contents">{topicItems}</div>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/features/ai-recap/ui/TopicCardItem.tsx
+++ b/apps/web/src/features/ai-recap/ui/TopicCardItem.tsx
@@ -4,12 +4,19 @@ const TopicCardItem = ({
   title,
   content,
   isPlaceholder = false,
+  className,
 }: {
   title: string;
   content: string;
   isPlaceholder?: boolean;
+  className?: string;
 }) => (
-  <Item className="bg-gray-75 flex-col items-stretch rounded-xl border-0 px-6.5 py-6 shadow-none">
+  <Item
+    className={cn(
+      "bg-gray-75 flex-col items-stretch rounded-xl border-0 px-6.5 py-6 shadow-none",
+      className,
+    )}
+  >
     <ItemContent className="gap-0 p-0">
       <ItemTitle className="text-heading-md text-gray-900">{title}</ItemTitle>
       <ItemDescription


### PR DESCRIPTION
## 작업 내용

- AI 리캡 하루 요약(`RecapSummary`) 반응형 처리: 모바일에서는 이미지 → 섹션(01/02) 세로 스택, `md` 이상에서는 섹션 | 이미지 좌우 배치
- 작은 화면 이미지 높이 `388px` 고정, 데스크톱에서는 영역 높이에 맞춰 `object-fill`로 채움
- AI 타임라인(`AiTimeline`) 반응형 처리: 폰에서는 헤더/컨텐츠 column, `md`(태블릿) 이상에서는 row
- 많이 둘러본 주제(`TopVisitedTopics`) 반응형 처리
  - `md` 이상: 키워드 박스 + 토픽 카드 3개를 동일 폭/높이로 flex-row 배치
  - 모바일: 키워드 → 카드가 각각 한 줄씩 세로 스택
  - 키워드 칩은 화면 크기와 무관하게 기존 비스듬한 배치를 유지하고, 컨테이너 중앙에 표시

## 작업 목적

- AI 리캡 페이지를 폰/태블릿/데스크톱에서 가독성과 레이아웃이 깨지지 않도록 맞추기 위함
- 카드별 반응형 경계를 `md`(태블릿) 기준으로 통일해, 폰에서만 column으로 전환되게 하기 위함

### 스크린샷 (선택)
