### PR TITLE
fix: AI 리캡 변경된 DTO 반영

### DIFF
--- a/apps/extension/src/features/ai-recap/ui/TodayRecapSection.tsx
+++ b/apps/extension/src/features/ai-recap/ui/TodayRecapSection.tsx
@@ -47,7 +47,7 @@ const TodayRecapSection = ({ recap }: { recap: RecapData }) => {
                 {t("todayRecap.measurementTimeLabel")}
               </p>
               <p className="text-body-2 text-gray-900">
-                {formatTimeRange(detail?.startedAt, detail?.closedAt) || "-"}
+                {formatTimeRange(detail?.startedAt, detail?.endedAt) || "-"}
               </p>
             </div>
           </div>

--- a/apps/web/app/ai-recap/error.tsx
+++ b/apps/web/app/ai-recap/error.tsx
@@ -1,7 +1,21 @@
 "use client";
 
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+
 import AiRecapEmptyPage from "@/pages/ai-recap/ui/AiRecapEmptyPage";
 
-export default function Error() {
+export default function Error({ reset }: { reset: () => void }) {
+  const searchParams = useSearchParams();
+  const query = searchParams?.toString() ?? "";
+  const failedQuery = useRef(query);
+
+  useEffect(() => {
+    if (failedQuery.current === query) return;
+
+    failedQuery.current = query;
+    reset();
+  }, [query, reset]);
+
   return <AiRecapEmptyPage />;
 }

--- a/apps/web/app/ai-recap/page.tsx
+++ b/apps/web/app/ai-recap/page.tsx
@@ -1,34 +1,18 @@
 import { Suspense } from "react";
 
 import AuthBoundary from "@/entities/auth/ui/AuthBoundary";
-import { serverAiRecapQueryOptions } from "@/features/ai-recap/api/ai-recap-query.server";
 import { AiRecapPage } from "@/pages/ai-recap/ui";
 import AiRecapLoadingPage from "@/pages/ai-recap/ui/AiRecapLoadingPage";
 import AiRecapUnloginPage from "@/pages/ai-recap/ui/AiRecapUnloginPage";
-import { getSafeQueryDate } from "@/shared/lib/date/safe-query-date";
-import FetchBoundary from "@/shared/lib/query/FetchBoundary";
 
-type AIRecapRouteProps = {
-  searchParams?: Promise<Record<string, string | string[] | undefined>>;
-};
-
-export default async function Page({ searchParams }: AIRecapRouteProps) {
-  const sp = searchParams ? await searchParams : {};
-
-  const rawDate = sp.date;
-  const dateParam = Array.isArray(rawDate) ? rawDate[0] : rawDate;
-
-  const date = getSafeQueryDate(dateParam);
-
+export default function Page() {
   return (
     <AuthBoundary
       fallback={<AiRecapUnloginPage />}
       loading={<AiRecapLoadingPage />}
     >
       <Suspense fallback={<AiRecapLoadingPage />}>
-        <FetchBoundary queries={[serverAiRecapQueryOptions(date)]}>
-          <AiRecapPage date={date} />
-        </FetchBoundary>
+        <AiRecapPage />
       </Suspense>
     </AuthBoundary>
   );

--- a/apps/web/src/features/ai-recap/ui/RecapSummary.tsx
+++ b/apps/web/src/features/ai-recap/ui/RecapSummary.tsx
@@ -77,7 +77,7 @@ const RecapSummary = ({ recap }: { recap: RecapData }) => {
                 {t("todayRecap.measurementTimeLabel")}
               </CardDescription>
               <p className="text-heading-rg m-0 text-gray-900">
-                {formatMeasuredRange(tc, detail?.startedAt, detail?.closedAt)}
+                {formatMeasuredRange(tc, detail?.startedAt, detail?.endedAt)}
               </p>
             </Stack>
           </Flex>

--- a/apps/web/src/pages/ai-recap/ui/AiRecapPage.tsx
+++ b/apps/web/src/pages/ai-recap/ui/AiRecapPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useSearchParams } from "next/navigation";
 import type { RecapData } from "@recap/api";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
@@ -12,18 +13,23 @@ import TopVisitedTopics from "@/features/ai-recap/ui/TopVisitedTopics";
 import AiRecapEmptyPage from "@/pages/ai-recap/ui/AiRecapEmptyPage";
 import AiRecapLoadingPage from "@/pages/ai-recap/ui/AiRecapLoadingPage";
 import AiRecapUnloginPage from "@/pages/ai-recap/ui/AiRecapUnloginPage";
+import { getSafeQueryDate } from "@/shared/lib/date/safe-query-date";
 
-const AiRecapPage = ({ date }: { date: string }) => (
+const AiRecapPage = () => (
   <AuthConsumer>
     {({ isReady, isLoggedIn }) => {
       if (!isReady) return <AiRecapLoadingPage />;
       if (!isLoggedIn) return <AiRecapUnloginPage />;
-      return <LoggedInRecap date={date} />;
+      return <LoggedInRecap />;
     }}
   </AuthConsumer>
 );
 
-const LoggedInRecap = ({ date }: { date: string }) => {
+const LoggedInRecap = () => {
+  const searchParams = useSearchParams();
+  const rawDate = searchParams?.get("date");
+  const date = getSafeQueryDate(rawDate);
+
   const { data: recap } = useSuspenseQuery({
     ...aiRecapQueryOptions(date),
     select: (data): RecapData | null => {

--- a/packages/api/src/domains/recap/generate-recap.schema.ts
+++ b/packages/api/src/domains/recap/generate-recap.schema.ts
@@ -1,14 +1,32 @@
 import { z } from "zod";
 
-import {
-  CreateResponseSchema,
-  dateStringSchema,
-  isoDurationStringSchema,
-} from "../../schemas";
+import { CreateResponseSchema, isoDurationStringSchema } from "../../schemas";
+
+const optionalText = z
+  .string()
+  .nullish()
+  .transform((value) => value ?? undefined);
+
+const text = z
+  .string()
+  .nullish()
+  .transform((value) => value ?? "");
+
+const optionalDate = z
+  .string()
+  .refine((value) => !Number.isNaN(Date.parse(value)), {
+    message: "Invalid date string",
+  })
+  .transform((value) => new Date(value))
+  .nullish()
+  .transform((value) => value ?? undefined)
+  .catch(undefined);
+
+const durationSeconds = isoDurationStringSchema.catch(0);
 
 export const RecapSectionSchema = z.object({
-  title: z.string(),
-  content: z.string(),
+  title: text,
+  content: text,
 });
 
 const RecapImageEnum = z.enum([
@@ -38,35 +56,35 @@ const RecapImageEnum = z.enum([
 export type RecapImageType = z.infer<typeof RecapImageEnum>;
 
 export const RecapTimelineSchema = z.object({
-  startedAt: z.string(),
-  endedAt: z.string(),
-  title: z.string(),
-  duration: isoDurationStringSchema,
+  startedAt: text,
+  endedAt: text,
+  title: text,
+  duration: durationSeconds,
 });
 
 export const RecapTopicSchema = z.object({
-  keyword: z.string(),
-  title: z.string(),
-  content: z.string(),
+  keyword: text,
+  title: text,
+  content: text,
 });
 
 export const RecapDetailSchema = z.object({
-  id: z.number(),
-  userId: z.number().optional(),
-  date: z.string().optional(),
-  title: z.string().optional(),
-  summary: z.string().optional(),
-  image: RecapImageEnum.nullable().optional(),
-  aiProvider: z.string().optional(),
-  startedAt: dateStringSchema.optional(),
-  closedAt: dateStringSchema.optional(),
+  id: optionalText,
+  userId: optionalText,
+  date: optionalText,
+  title: optionalText,
+  summary: optionalText,
+  image: RecapImageEnum.nullish().catch(null),
+  aiProvider: optionalText,
+  startedAt: optionalDate,
+  endedAt: optionalDate,
 });
 
 export const RecapSchema = z.object({
-  recap: RecapDetailSchema.optional(),
-  sections: z.array(RecapSectionSchema).optional(),
-  timelines: z.array(RecapTimelineSchema).optional(),
-  topics: z.array(RecapTopicSchema).optional(),
+  recap: RecapDetailSchema.optional().catch(undefined),
+  sections: z.array(RecapSectionSchema).optional().catch([]),
+  timelines: z.array(RecapTimelineSchema).optional().catch([]),
+  topics: z.array(RecapTopicSchema).optional().catch([]),
 });
 
 export const GetRecapResponseSchema = CreateResponseSchema(RecapSchema);


### PR DESCRIPTION
## 작업 내용

- AI 리캡 API 응답 DTO 변경 반영
  - `recap.id` / `userId`를 number → UUID string(null 허용)으로 수정
  - `closedAt` → `endedAt` 필드명 맞춤
  - null/누락/깨진 값에 대한 Zod 검증을 관대하게 처리해 스키마 실패로 페이지 전체가 죽지 않도록 수정
- AI 리캡 날짜 조회를 서버 prop 대신 `useSearchParams` 기반으로 변경해 date 변경 시 queryKey가 갱신되도록 수정
- `error.tsx`에서 search param 변경 시 `reset()`을 호출해 에러 바운더리에 갇히지 않도록 수정
- 웹/익스텐션 측정 시간 표시를 `endedAt` 기준으로 통일

## 작업 목적

백엔드 AI 리캡 DTO가 UUID string 기반으로 바뀌었는데 프론트 Zod 스키마가 여전히 number/`closedAt`을 기대해 검증 에러가 발생했고, 그 에러가 `useSuspenseQuery` → `error.tsx`로 올라가 empty fallback에 고정되는 문제를 해결하기 위함입니다.

또한 날짜를 서버 Component prop으로만 넘기던 구조 때문에 URL date 변경이 클라이언트 query에 반영되지 않던 문제를 함께 수정했습니다.

### 스크린샷 (선택)
