### PR TITLE
fix: ToggleGroup 아이템 재선택 시 빈 값으로 해제되지 않게 수정

### DIFF
--- a/apps/extension/src/shared/ui/ToggleGroup.tsx
+++ b/apps/extension/src/shared/ui/ToggleGroup.tsx
@@ -32,12 +32,23 @@ function ToggleGroup<T extends string = string>({
   className,
   ...props
 }: ToggleGroupProps<T>) {
-  return (
-    <BaseToggleGroup
-      className={cn(className)}
-      {...(props as ToggleGroupPrimitiveProps)}
-    />
-  );
+  if (props.type === "single") {
+    const { onValueChange, ...singleProps } = props;
+
+    return (
+      <BaseToggleGroup
+        {...singleProps}
+        className={cn(className)}
+        onValueChange={(value: string) => {
+          if (value === "") return;
+
+          onValueChange?.(value as T);
+        }}
+      />
+    );
+  }
+
+  return <BaseToggleGroup {...props} className={cn(className)} />;
 }
 ToggleGroup.displayName = "ToggleGroup";
 

--- a/apps/web/src/shared/ui/ToggleGroup.tsx
+++ b/apps/web/src/shared/ui/ToggleGroup.tsx
@@ -43,10 +43,26 @@ function ToggleGroup<T extends string = string>({
   className,
   ...props
 }: ToggleGroupProps<T>) {
+  if (props.type === "single") {
+    const { onValueChange, ...singleProps } = props;
+
+    return (
+      <ToggleGroupPrimitive
+        {...singleProps}
+        className={cn(toggleGroupRootClassName, className)}
+        onValueChange={(value: string) => {
+          if (value === "") return;
+
+          onValueChange?.(value as T);
+        }}
+      />
+    );
+  }
+
   return (
     <ToggleGroupPrimitive
+      {...props}
       className={cn(toggleGroupRootClassName, className)}
-      {...(props as ToggleGroupPrimitiveProps)}
     />
   );
 }


### PR DESCRIPTION
## 작업 내용

- 웹/익스텐션 공통 `ToggleGroup` 래퍼에서 `type="single"`일 때, 이미 선택된 항목을 다시 눌러도 빈 값(`""`)으로 해제되지 않도록 처리
- Radix single ToggleGroup의 재클릭 해제 콜백을 무시해 `onValueChange`에는 유효한 값만 전달

## 작업 목적

- 스크린타임 등에서 같은 토글을 다시 눌렀을 때 `mode`가 빈 문자열이 되며 `SCREEN_TIME_MODE_CONFIG` 조회가 실패해 화면이 white out 되던 문제를 막기 위함
- 선택 해제가 필요 없는 single ToggleGroup UX를 웹·익스텐션에서 동일하게 유지

### 스크린샷 (선택)

- (선택 토글 재클릭 전/후: 화면이 유지되는지 확인)
